### PR TITLE
Fixing two issues in jenkins::config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,11 +3,13 @@
 # Hash with config options to set in sysconfig/jenkins defaults/jenkins
 #
 # Example use
-# 
-# class{ 'jenkins::config': 
-#   config_hash => { 'PORT' => { 'value' => '9090' }, 'AJP_PORT' => { 'value' => '9009' } } 
+#
+# class{ 'jenkins::config':
+#   config_hash => {
+#     'PORT' => { 'value' => '9090' }, 'AJP_PORT' => { 'value' => '9009' }
+#   }
 # }
-# 
+#
 class jenkins::config(
   $config_hash = {},
 ) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,18 +17,20 @@
 # Hash with config options to set in sysconfig/jenkins defaults/jenkins
 #
 # Example use
-# 
-# class{ 'jenkins::config': 
-#   config_hash => { 'PORT' => { 'value' => '9090' }, 'AJP_PORT' => { 'value' => '9009' } } 
+#
+# class{ 'jenkins::config':
+#   config_hash => {
+#     'PORT' => { 'value' => '9090' }, 'AJP_PORT' => { 'value' => '9009' }
+#   }
 # }
-# 
+#
 # plugin_hash = undef (Default)
 # Hash with config plugins to install
 #
 # Example use
-# 
-# class{ 'jenkins::plugins': 
-#   plugin_hash => { 
+#
+# class{ 'jenkins::plugins':
+#   plugin_hash => {
 #     'git' -> { version => '1.1.1' },
 #     'parameterized-trigger' => {},
 #     'multiple-scms' => {},
@@ -36,11 +38,11 @@
 #     'token-macro' => {},
 #   }
 # }
-# 
+#
 # OR in Hiera
-# 
+#
 # jenkins::plugin_hash:
-#    'git': 
+#    'git':
 #       version: 1.1.1
 #    'parameterized-trigger': {}
 #    'multiple-scms': {}
@@ -48,8 +50,8 @@
 #    'token-macro': {}
 #
 class jenkins(
-  $version     = 'installed', 
-  $lts         = 0, 
+  $version     = 'installed',
+  $lts         = 0,
   $repo        = 1,
   $config_hash = undef,
   $plugin_hash = undef,

--- a/manifests/plugin/install.pp
+++ b/manifests/plugin/install.pp
@@ -1,3 +1,5 @@
+# Define: jenkins::plugin::install
+#
 define jenkins::plugin::install($version=0) {
   $plugin     = "${name}.hpi"
   $plugin_parent_dir = '/var/lib/jenkins'

--- a/manifests/plugins.pp
+++ b/manifests/plugins.pp
@@ -1,3 +1,5 @@
+# Class: jenkins::plugins
+#
 class jenkins::plugins (
   $plugin_hash = {}
 ) {

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -1,3 +1,5 @@
+# Class: jenkins::repo::debian
+#
 class jenkins::repo::debian ( $lts=0 )
 {
 

--- a/manifests/repo/el.pp
+++ b/manifests/repo/el.pp
@@ -1,3 +1,5 @@
+# Class: jenkins::repo::el
+#
 class jenkins::repo::el ( $lts=0 )
 {
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,3 +1,5 @@
+# Class: jenkins::service
+#
 class jenkins::service {
   service { 'jenkins':
     ensure     => running,

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -1,7 +1,9 @@
 # Class: jenkins::slave
 #
 #
-#  ensure is not immplemented yet, since i'm assuming you want to actually run the slave by declaring it..
+#  ensure is not immplemented yet, since i'm
+#  assuming you want to actually run the slave
+#  by declaring it..
 #
 class jenkins::slave (
   $masterurl = undef,

--- a/manifests/sysconfig.pp
+++ b/manifests/sysconfig.pp
@@ -1,3 +1,5 @@
+# Class: jenkins::sysconfig
+#
 define jenkins::sysconfig ( $value ) {
   $path = $::osfamily ? {
     RedHat  => '/etc/sysconfig',


### PR DESCRIPTION
1) For the Debian family (Checked Debian Wheezy and Ubuntu Precise) the defaults folder is in /etc/default instead of /etc/defaults
2) Removed prefixing of JENKINS_ on each variable as it removes flexibilty. If a user wants to add that - they can. This now enables me to set things like
HTTP_PORT correctly. Also - as a word of caution, file_line adds new resources to the end of the file - This may cause issues (For example, if HTTP_PORT is set after
JENKINS_ARGS then HTTP_PORT will not actually be read in, as JENKINS_ARGS calls it.

Tested on Ubuntu Precise 12.04 (Only checked the default part on Wheezy, didn't test - Can't imagine it being any different though)

```
class { 'jenkins':
  config_hash => {
    'HTTP_PORT' => { 'value' => 2222 }
  }
}
```

Was applied to my test node successfully.

Tested and fixed a few issues with rtyler/puppet-jenkins#54
