### PR TITLE
Update plugin existance test for both hpi and jpi

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -43,7 +43,7 @@ define jenkins::plugin($version=0) {
       cwd        => $plugin_dir,
       require    => File[$plugin_dir],
       path       => ['/usr/bin', '/usr/sbin',],
-      unless     => "test -f ${plugin_dir}/${plugin}",
+      unless     => "test -f ${plugin_dir}/${name}.hpi || test -f ${plugin_dir}/${name}.jpi",
   }
 
   file {


### PR DESCRIPTION
For some reason, after jenkins restarted, it renames .hpi to jpi. e.g. ant plugin
Because of this, puppet will install the plugin everytime it runs.
