### PR TITLE
Add notify relationship between jenkins::config ~> jenkins::service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,8 +78,9 @@ class jenkins(
   include jenkins::firewall
 
   Class['jenkins::repo'] ->
-      Class['jenkins::package'] ->
-          Class['jenkins::service']
+    Class['jenkins::package'] ->
+      Class['jenkins::config'] ~>
+        Class['jenkins::service']
 }
 
 # vim: ts=2 et sw=2 autoindent


### PR DESCRIPTION
When the jenkins::config parameters are changed (changing HTTP_PORT for example) the Jenkins service was not refreshed.

This fixes this issue.
