### PR TITLE
initial suse support for jenkins puppet module

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -10,3 +10,4 @@ project_page 'https://github.com/rtyler/puppet-jenkins'
 ## Add dependencies, if any:
 dependency 'puppetlabs/stdlib', '>= 2.0.0'
 dependency 'puppetlabs/apt', '>= 0.0.3'
+dependency 'darin/zypprepo', '>= 1.0.1'

--- a/README.markdown
+++ b/README.markdown
@@ -68,6 +68,7 @@ The dependencies for this module currently are:
 
 * [stdlib module](http://forge.puppetlabs.com/puppetlabs/stdlib)
 * [apt module](http://forge.puppetlabs.com/puppetlabs/apt) (for Debian/Ubuntu users)
+* [zypprepo](https://forge.puppetlabs.com/darin/zypprepo) (for Suse users)
 
 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,8 @@
 #     'PORT' => { 'value' => '9090' }, 'AJP_PORT' => { 'value' => '9009' }
 #   }
 # }
+# The config hash on opensuse has a prefix JENKINS_ (JENKINS_PORT)
+# 
 #
 # plugin_hash = undef (Default)
 # Hash with config plugins to install

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -35,6 +35,14 @@ class jenkins::repo ($lts=0, $repo=1) {
             before  => Anchor['jenkins::repo::omega'],
         }
       }
+      'Suse': {
+        class {
+          'jenkins::repo::suse':
+            lts     => $lts,
+            require => Anchor['jenkins::repo::alpha'],
+            before  => Anchor['jenkins::repo::omega'],
+        }
+      }
 
       default: {
         fail( "Unsupported OS family: ${::osfamily}" )

--- a/manifests/repo/suse.pp
+++ b/manifests/repo/suse.pp
@@ -1,0 +1,26 @@
+# Class: jenkins::repo::suse
+#
+class jenkins::repo::suse ( $lts=0 )
+{
+
+  include 'jenkins::repo'
+
+  if $jenkins::repo::lts == 0 {
+    zypprepo {'jenkins':
+      descr    => 'Jenkins',
+      baseurl  => 'http://pkg.jenkins-ci.org/opensuse/',
+      gpgcheck => 1,
+      gpgkey   => 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key'
+    }
+  }
+  elsif $jenkins::repo::lts == 1 {
+    yumrepo {'jenkins':
+      descr    => 'Jenkins',
+      baseurl  => 'http://pkg.jenkins-ci.org/opensuse-stable/',
+      gpgcheck => 1,
+      gpgkey   => 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key'
+    }
+  }
+
+}
+

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -24,6 +24,9 @@ class jenkins::slave (
     'RedHat': {
       $java_package = 'java-1.6.0-openjdk'
     }
+    'Suse': {
+      $java_package = 'java_1_7_0-openjdk'
+    }
     'Linux': {
       $java_package = 'java-1.6.0-openjdk'
     }

--- a/manifests/sysconfig.pp
+++ b/manifests/sysconfig.pp
@@ -3,6 +3,7 @@
 define jenkins::sysconfig ( $value ) {
   $path = $::osfamily ? {
     RedHat  => '/etc/sysconfig',
+    Suse    => '/etc/sysconfig',
     Debian  => '/etc/default',
     default => fail( "Unsupported OSFamily ${::osfamily}" )
   }

--- a/spec/classes/jenkins_spec.rb
+++ b/spec/classes/jenkins_spec.rb
@@ -13,6 +13,7 @@ describe 'jenkins' do
     it { should contain_class 'jenkins::service' }
     it { should contain_class 'jenkins::repo::el' }
     it { should_not contain_class 'jenkins::repo::debian' }
+    it { should_not contain_class 'jenkins::repo::suse' }
   end
 
   let(:facts) do
@@ -42,6 +43,21 @@ describe 'jenkins' do
     it { should contain_class 'jenkins::package' }
     it { should contain_class 'jenkins::service' }
     it { should contain_class 'jenkins::repo::debian' }
+    it { should_not contain_class 'jenkins::repo::el' }
+    it { should_not contain_class 'jenkins::repo::suse' }
+  end
+  
+  let(:facts) do
+    { :osfamily => 'Suse' }
+  end
+
+  describe "on Suse" do
+    it { should contain_class 'jenkins' }
+    it { should contain_class 'jenkins::repo' }
+    it { should contain_class 'jenkins::package' }
+    it { should contain_class 'jenkins::service' }
+    it { should contain_class 'jenkins::repo::suse' }
+    it { should_not contain_class 'jenkins::repo::debian' }
     it { should_not contain_class 'jenkins::repo::el' }
   end
 end


### PR DESCRIPTION
These additions make your jenkins module work on opensuse.

Test: opensuse 12.3 with java 1.7.0 jdk from suse repo.

Sorry haven't made the spec/test for this...

only extra requirement is zypprepo from the forge.
