### PR TITLE
Firewall resource order

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,7 +86,7 @@ class jenkins(
   Anchor['jenkins::begin'] ->
     Class['jenkins::repo'] ->
       Class['jenkins::package'] ->
-        Class['jenkins::config']
+        Class['jenkins::config'] ->
           Class['jenkins::plugins']~>
             Class['jenkins::service'] ->
                 Anchor['jenkins::end']


### PR DESCRIPTION
Fixes:
- error when configure_firewall is false.
- missing relationship between Class['jenkins::config'] and Class['jenkins::plugins']

FWIW, I don't agree with defaulting configure_firewall to true.  The module makes an assumption that I want it to manage my firewall which I think it has no business messing with.  You really can't assume how the module consumer wants their firewall to look.  There's of course no clear consensus on this idea and I've found about a 50/50 split between those modules that manage the firewall by default and those that don't.
