### PR TITLE
Fix slave documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -123,7 +123,6 @@ An example:
 
     node /jenkins-slave.*/ {
       class { 'jenkins::slave':
-        ensure => 'enabled',
         masterurl => 'http://jenkins-master1.domain.com:8080',
         ui_user => 'adminuser',
         ui_pass => 'adminpass',


### PR DESCRIPTION
$ensure is not available with jenkins::slave
