### PR TITLE
Download plugins to a .jpi file

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -2,7 +2,8 @@
 #
 #
 define jenkins::plugin($version=0) {
-  $plugin            = "${name}.hpi"
+  $plugin            = "${name}.jpi"
+  $plugin_dl         = "${name}.hpi"
   $plugin_dir        = '/var/lib/jenkins/plugins'
   $plugin_parent_dir = '/var/lib/jenkins'
 
@@ -39,11 +40,11 @@ define jenkins::plugin($version=0) {
 
   exec {
     "download-${name}" :
-      command    => "wget --no-check-certificate ${base_url}${plugin}",
+      command    => "wget --no-check-certificate ${base_url}${plugin_dl} -O ${plugin}",
       cwd        => $plugin_dir,
       require    => File[$plugin_dir],
       path       => ['/usr/bin', '/usr/sbin',],
-      unless     => "test -f ${plugin_dir}/${name}.hpi || test -f ${plugin_dir}/${name}.jpi",
+      unless     => "test -f ${plugin_dir}/${plugin}",
   }
 
   file {


### PR DESCRIPTION
This appears to mirror the current behavior of Jenkins.\* It prevents an issue where the puppet module downloads a .hpi and then Jenkins on start downloads and unpacks a .jpi and deletes the .hpi. The next time Puppet runs it will create an empty .hpi file via the File resource and break the plugin.
- Not sure when this practice started and if an older behavior needs to be supported. If it does there's more changes needed to get this to all work properly.
