### PR TITLE
Bump to latest swarm version.

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -9,7 +9,7 @@ class jenkins::slave (
   $masterurl = undef,
   $ui_user = undef,
   $ui_pass = undef,
-  $version = '1.8',
+  $version = '1.9',
   $executors = 2,
   $manage_slave_user = 1,
   $slave_user = 'jenkins-slave',


### PR DESCRIPTION
Bump from 1.8 to 1.9.

This should possibly be handled by providing a jenkins::params class which would keep the version consistent between slaves and when installing on the master.
