### PR TITLE
Manage plugin configuration with puppet

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -1,10 +1,21 @@
 #
+# config_filename = undef
+#   Name of the config file for this plugin.
 #
+# config_content = undef
+#   Content of the config file for this plugin. It is up to the caller to
+#   create this content from a template or any other mean.
 #
-define jenkins::plugin($version=0) {
+define jenkins::plugin (
+  $version         = 0,
+  $manage_config   = false,
+  $config_filename = undef,
+  $config_content  = undef,
+) {
   $plugin            = "${name}.hpi"
   $plugin_dir        = '/var/lib/jenkins/plugins'
   $plugin_parent_dir = '/var/lib/jenkins'
+  validate_bool ($manage_config)
 
   if ($version != 0) {
     $base_url = "http://updates.jenkins-ci.org/download/plugins/${name}/${version}/"
@@ -52,5 +63,20 @@ define jenkins::plugin($version=0) {
       owner   => 'jenkins',
       mode    => '0644',
       notify  => Service['jenkins']
+  }
+  
+  if $manage_config {
+    if $config_filename == undef or $config_content == undef {
+      fail 'To deploy config file for plugin, you need to specify both $config_filename and $config_content'
+    }
+
+    file {"${plugin_parent_dir}/${config_filename}":
+      ensure  => present,
+      content => $config_content,
+      owner   => 'jenkins',
+      group   => 'jenkins',
+      mode    => '0644',
+      notify  => Service['jenkins']
+    }
   }
 }

--- a/manifests/plugin/git.pp
+++ b/manifests/plugin/git.pp
@@ -1,0 +1,23 @@
+class jenkins::plugin::git (
+  $version            = 0,
+  $manage_config      = false,
+  $config_filename    = 'hudson.plugins.git.GitSCM.xml',
+  $config_content     = undef,
+  $git_name           = 'Jenkins',
+  $git_email          = 'jenkins@example.net',
+  $git_create_account = false,) {
+  validate_bool($git_create_account)
+
+  if $config_content == undef {
+    $real_content = template('jenkins/plugin/git.config.xml.erb')
+  } else {
+    $real_content = $config_content
+  }
+
+  jenkins::plugin { 'git':
+    version         => $version,
+    manage_config   => $manage_config,
+    config_filename => $config_filename,
+    config_content  => $real_content,
+  }
+}

--- a/templates/plugin/git.config.xml.erb
+++ b/templates/plugin/git.config.xml.erb
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson.plugins.git.GitSCM_-DescriptorImpl plugin="git@1.5.0">
+  <generation>1</generation>
+  <globalConfigName><%= @git_name %></globalConfigName>
+  <globalConfigEmail><%= @git_email %></globalConfigEmail>
+  <createAccountBasedOnEmail><%= @git_create_account %></createAccountBasedOnEmail>
+</hudson.plugins.git.GitSCM_-DescriptorImpl>


### PR DESCRIPTION
I would like to be able to completely manage Jenkins from Puppet, including its configuration.This would improve tracking of changes to the configuration and ensure that we can restore a Jenkins instance with minimum reliance on backups.

To enable this, plugin configuration needs to be managed by Puppet.

Each plugin will need different configuration parameters, and different configuration templates. It is not reasonable to expect the puppet-jenkins module to support all plugins. The most common plugins should be supported, but it should be possible to add support for other plugins without modifying puppet-jenkins (Open / Close principle).

This commit implements configuration management for the git plugin. It extends the current plugin.pp with the ability to manage configuration in a very generic way and adds a jenkins::plugin::git class that implement git specific behaviour.

This pull request is not meant to be merged as-is, but to start a discussion on wheter it is a good idea to support plugin configuration, or at least to support the generic mechanism of plugin configuration.
