### PR TITLE
Added support for Travis-CI and main ruby-versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: ruby
+before_install:
+  - gem install bundler
+
+script: 
+  - rake build
+  - rake spec
+  
+#notifications:
+#  email:
+#  - # uncomment it and add the maintainer e-mail if you want to receive e-mails on error
+
+rvm:
+  - ruby-head # to ensure that the nex ruby version will not create problems
+  - 2.0.0    
+  - 1.9.3
+  - 1.8.7
+  - jruby-19mode


### PR DESCRIPTION
I added also ruby-head to the ruby versions to be tested, as it will make us aware of possible problems with upcoming versions of ruby.

If you want some ruby-versions (e.g. ruby-head not failing your travis build) add the following lines to .travis.yaml
matrix:
-  allow_failures:
-    - rvm: ruby-head

Replaces https://github.com/jenkinsci/puppet-jenkins/pull/34

See also Travis https://travis-ci.org/ngiger/puppet-jenkins/builds/11764964
