### PR TITLE
debian compatibility and variable use

### DIFF
--- a/templates/jenkins-slave.erb
+++ b/templates/jenkins-slave.erb
@@ -19,7 +19,7 @@ fi
 
 slave_start() {
   echo Starting Jenkins Slave...
-  $RUNUSER - <%= @slave_user -%> -c 'java -jar <%= @slave_home -%>/<%= @client_jar -%> <%= @ui_user_flag -%> <%= @ui_pass_flag -%> -name <%= @fqdn -%> -executors <%= @executors -%> <%= @masterurl_flag -%> <%= @labels_flag -%> &'
+  $RUNUSER - <%= @slave_user -%> -c 'java -jar <%= @slave_home -%>/<%= @client_jar -%> <%= @ui_user_flag -%> <%= @ui_pass_flag -%> -name <%= @fqdn || @hostname -%> -executors <%= @executors -%> <%= @masterurl_flag -%> <%= @labels_flag -%> &'
   pgrep -f -u <%= @slave_user -%> <%= @client_jar -%> > $PID_FILE
   RETVAL=$?
   [ $RETVAL -eq 0 ] && touch $LOCK_FILE


### PR DESCRIPTION
This patch fixes the use of `/etc/init.d/functions` which seems to be not standard across linux distributions. Furthermore the template now uses the global variables instead of the local ones / some functions.
