### PR TITLE
Fix rm: command not found

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -54,7 +54,7 @@ define jenkins::plugin($version=0) {
         command    => "rm -rf ${name} ${name}.* && wget --no-check-certificate ${base_url}${plugin}",
         cwd        => $plugin_dir,
         require    => [File[$plugin_dir], Package['wget']],
-        path       => ['/usr/bin', '/usr/sbin',],
+        path       => ['/usr/bin', '/usr/sbin', '/bin'],
     }
   }
 


### PR DESCRIPTION
Plugins failed to install, with the error 'rm: command not found'. Adding `/bin` to the `exec`s path solved this issue.
