### PR TITLE
Check if jenkins_home/plugins exists

### DIFF
--- a/lib/facter/jenkins.rb
+++ b/lib/facter/jenkins.rb
@@ -7,7 +7,7 @@ jenkins_home = Facter::Util::Resolution.exec("echo ~jenkins")
 plugins = "#{jenkins_home}/plugins"
 jenkins_plugins = ''
 
-if File.directory?(jenkins_home)
+if File.directory?(plugins)
   # Get a list of all plugins + versions
   Dir.entries(plugins).select do |plugin|
     if (File.directory?("#{plugins}/#{plugin}") == true) && !(plugin == '..' || plugin == '.')


### PR DESCRIPTION
The code was raising an exception if ~jenkins
existed, but ~jenkins/plugins didn't. Change
the code to check for plugins from jenkins_home.
