### PR TITLE
fix optional dependency

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -47,7 +47,7 @@ define jenkins::plugin($version=0) {
         ensure => present;
     }
   }
-  
+
   file {
     "${plugin_dir}/${plugin}" :
       owner   => 'jenkins',


### PR DESCRIPTION
This PR fixes the optional dependency between `File["${plugin_dir}/${plugin}"]` and `Exec["download-${name}"]`.
