### PR TITLE
Resolve puppet warnings

### DIFF
--- a/templates/jenkins-slave.erb
+++ b/templates/jenkins-slave.erb
@@ -15,8 +15,8 @@ LOCK_FILE=/var/lock/jenkins-slave
 
 slave_start() {
   echo Starting Jenkins Slave...
-  runuser - <%= slave_user -%> -c 'java -jar <%= slave_home -%>/<%= client_jar -%> <%= ui_user_flag -%> <%= ui_pass_flag -%> -name <%= fqdn -%> -executors <%= executors -%> <%= masterurl_flag -%> <%= labels_flag -%> &'
-  pgrep -f -u <%= slave_user -%> <%= client_jar -%> > $PID_FILE
+  runuser - <%= @slave_user -%> -c 'java -jar <%= @slave_home -%>/<%= @client_jar -%> <%= @ui_user_flag -%> <%= @ui_pass_flag -%> -name <%= @fqdn -%> -executors <%= @executors -%> <%= @masterurl_flag -%> <%= @labels_flag -%> &'
+  pgrep -f -u <%= @slave_user -%> <%= @client_jar -%> > $PID_FILE
   RETVAL=$?
   [ $RETVAL -eq 0 ] && touch $LOCK_FILE
 }


### PR DESCRIPTION
The following warning were emitted while compiling the catalog

```
Warning: Variable access via 'slave_user' is deprecated. Use '@slave_user' instead. template[/home/USERNAME/Code/work/puppet/modules/jenkins/templates/jenkins-slave.erb]:18
   (at /home/USERNAME/Code/work/puppet/modules/jenkins/templates/jenkins-slave.erb:18:in `result')
Warning: Variable access via 'slave_user' is deprecated. Use '@slave_user' instead. template[/home/USERNAME/Code/work/puppet/modules/jenkins/templates/jenkins-slave.erb]:19
   (at /home/USERNAME/Code/work/puppet/modules/jenkins/templates/jenkins-slave.erb:19:in `result')
```

To reduce the noise generated (and be up-to-date with current puppet standards), I changed the variables to their instance-variable equivalent.
