### PR TITLE
Creating home directory for jenkins user

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -36,9 +36,9 @@ define jenkins::plugin($version=0) {
   if (!defined(User['jenkins'])) {
     user {
       'jenkins' :
-        ensure     => present,
-        managehome => true,
-        require    => Package['jenkins'];
+        ensure  => present,
+        home    => $plugin_parent_dir,
+        require => Package['jenkins'];
     }
   }
 

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -6,7 +6,7 @@ describe 'jenkins::plugin' do
   it { should contain_file('/var/lib/jenkins') }
   it { should contain_file('/var/lib/jenkins/plugins') }
   it { should contain_group('jenkins') }
-  it { should contain_user('jenkins').with('managehome' => 'true') }
+  it { should contain_user('jenkins').with('home' => '/var/lib/jenkins') }
 
   describe 'without version' do
     it { should contain_exec('download-myplug').with_command('rm -rf myplug myplug.* && wget --no-check-certificate http://updates.jenkins-ci.org/latest/myplug.hpi') }


### PR DESCRIPTION
Jenkins plugins such as Maven, will use "~/.m2" as the default local repository location. Since we are creating the jenkins user if it's not defined, we should allow puppet to create the home directory so plugins such as Maven can work out-of-the-box.
