### PR TITLE
replace str2bool with validate_bool

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,21 +80,18 @@ class jenkins(
   $proxy_port         = undef,
 ) inherits jenkins::params {
 
-  $lts_real = str2bool($lts)
-  $java_real = str2bool($install_java)
-  $repo_real = str2bool($repo)
-  $firewall_real = str2bool($configure_firewall)
+  validate_bool($lts, $install_java, $repo, $configure_firewall)
 
   anchor {'jenkins::begin':}
   anchor {'jenkins::end':}
 
-  if $java_real {
+  if $install_java {
     class {'java':
       distribution => 'jdk'
     }
   }
 
-  if $repo_real {
+  if $repo {
     class {'jenkins::repo':}
   }
 
@@ -121,7 +118,7 @@ class jenkins(
 
   class {'jenkins::service':}
 
-  if $firewall_real {
+  if $configure_firewall {
     class {'jenkins::firewall':}
   }
 
@@ -132,21 +129,21 @@ class jenkins(
           Class['jenkins::service'] ->
               Anchor['jenkins::end']
 
-  if $java_real {
+  if $install_java {
     Anchor['jenkins::begin'] ->
       Class['java'] ->
         Class['jenkins::package'] ->
           Anchor['jenkins::end']
   }
 
-  if $repo_real {
+  if $repo {
     Anchor['jenkins::begin'] ->
       Class['jenkins::repo'] ->
         Class['jenkins::package'] ->
           Anchor['jenkins::end']
   }
 
-  if $firewall_real {
+  if $configure_firewall {
     Class['jenkins::service'] ->
       Class['jenkins::firewall'] ->
         Anchor['jenkins::end']

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -3,7 +3,7 @@
 #
 class jenkins::repo {
 
-  if ( $::jenkins::repo_real ) {
+  if ( $::jenkins::repo ) {
     case $::osfamily {
 
       'RedHat', 'Linux': {

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -2,7 +2,7 @@
 #
 class jenkins::repo::debian
 {
-  if $::jenkins::lts_real  {
+  if $::jenkins::lts  {
     apt::source { 'jenkins':
       location    => 'http://pkg.jenkins-ci.org/debian-stable',
       release     => 'binary/',

--- a/manifests/repo/el.pp
+++ b/manifests/repo/el.pp
@@ -3,7 +3,7 @@
 class jenkins::repo::el
 {
 
-  if $::jenkins::lts_real  {
+  if $::jenkins::lts  {
     yumrepo {'jenkins':
       descr    => 'Jenkins',
       baseurl  => 'http://pkg.jenkins-ci.org/redhat-stable/',

--- a/manifests/repo/suse.pp
+++ b/manifests/repo/suse.pp
@@ -3,7 +3,7 @@
 class jenkins::repo::suse
 {
 
-  if $::jenkins::lts_real {
+  if $::jenkins::lts {
     zypprepo {'jenkins':
       descr    => 'Jenkins',
       baseurl  => 'http://pkg.jenkins-ci.org/opensuse-stable/',

--- a/spec/classes/jenkins_repo_debian_spec.rb
+++ b/spec/classes/jenkins_repo_debian_spec.rb
@@ -9,7 +9,7 @@ describe 'jenkins::repo::debian' do
   end
 
   describe 'lts = true' do
-    let(:pre_condition) { ['class jenkins { $lts_real = true }', 'include jenkins'] }
+    let(:pre_condition) { ['class jenkins { $lts = true }', 'include jenkins'] }
     it { should contain_apt__source('jenkins').with_location('http://pkg.jenkins-ci.org/debian-stable') }
   end
 

--- a/spec/classes/jenkins_repo_el_spec.rb
+++ b/spec/classes/jenkins_repo_el_spec.rb
@@ -9,7 +9,7 @@ describe 'jenkins::repo::el' do
   end
 
   describe 'lts = true' do
-    let(:pre_condition) { ['class jenkins { $lts_real = true }', 'include jenkins'] }
+    let(:pre_condition) { ['class jenkins { $lts = true }', 'include jenkins'] }
     it { should contain_yumrepo('jenkins').with_baseurl('http://pkg.jenkins-ci.org/redhat-stable/') }
   end
 

--- a/spec/classes/jenkins_repo_spec.rb
+++ b/spec/classes/jenkins_repo_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'jenkins::repo' do
 
   describe 'default' do
-    let(:pre_condition) { ['class jenkins { $repo_real = 1 }', 'include jenkins'] }
+    let(:pre_condition) { ['class jenkins { $repo = true }', 'include jenkins'] }
     describe 'RedHat' do
       let(:facts) { { :osfamily => 'RedHat' } }
       it { should contain_class('jenkins::repo::el') }
@@ -13,7 +13,7 @@ describe 'jenkins::repo' do
       let(:facts) { { :osfamily => 'Linux' } }
       it { should contain_class('jenkins::repo::el') }
     end
-    
+
     describe 'Suse' do
       let(:facts) { { :osfamily => 'Suse' } }
       it { should contain_class('jenkins::repo::suse') }
@@ -31,7 +31,7 @@ describe 'jenkins::repo' do
   end
 
   describe 'repo = 0' do
-    let(:pre_condition) { ['class jenkins { $repo = 0 }', 'include jenkins'] }
+    let(:pre_condition) { ['class jenkins { $repo = false }', 'include jenkins'] }
     it { should_not contain_class('jenkins::repo::el') }
     it { should_not contain_class('jenkins::repo::suse') }
     it { should_not contain_class('jenkins::repo::debian') }

--- a/spec/classes/jenkins_repo_suse_spec.rb
+++ b/spec/classes/jenkins_repo_suse_spec.rb
@@ -9,7 +9,7 @@ describe 'jenkins::repo::suse' do
   end
 
   describe 'lts = true' do
-    let(:pre_condition) { ['class jenkins { $lts_real = true }', 'include jenkins'] }
+    let(:pre_condition) { ['class jenkins { $lts = true }', 'include jenkins'] }
     it { should contain_zypprepo('jenkins').with_baseurl('http://pkg.jenkins-ci.org/opensuse-stable/') }
   end
 


### PR DESCRIPTION
When working on the sensu puppet module one of the module users pointed out that the latest PE only supports stdlib 3.2.0 and str2bool was introduced in stdlib 4.0.0.  I'm not aware of any users this is actively presenting a problem for, but using str2bool does prevent PE users from using this module.  #77 highlighted this was in use for me.

Feel free to just close if PE support isn't needed.
