### PR TITLE
confine fact to only run on linux boxes

### DIFF
--- a/lib/facter/jenkins.rb
+++ b/lib/facter/jenkins.rb
@@ -3,30 +3,32 @@
 # Creates a fact 'jenkins_plugins' containing a comma-delimited string of all
 # jenkins plugins + versions.
 #
-jenkins_home = Facter::Util::Resolution.exec("echo ~jenkins")
-plugins = "#{jenkins_home}/plugins"
-jenkins_plugins = ''
+#
+Facter.add('jenkins_plugins') do
+  confine :kernel => "Linux"
 
-if File.directory?(plugins)
-  # Get a list of all plugins + versions
-  Dir.entries(plugins).select do |plugin|
-    if (File.directory?("#{plugins}/#{plugin}") == true) && !(plugin == '..' || plugin == '.')
-      begin
-	    contents = File.read("#{plugins}/#{plugin}/META-INF/MANIFEST.MF")
-      contents =~ (/Plugin\-Version:\s+([\d\.]+)/)
-      version = $1
-	    jenkins_plugins = "#{plugin} #{version}, " + jenkins_plugins
-      rescue
-        # Nothing really to do about it, failing means no version which will 
-        # result in a new plugin if needed
+  setcode do
+    jenkins_home = Facter::Util::Resolution.exec("echo ~jenkins")
+    plugins = "#{jenkins_home}/plugins"
+    jenkins_plugins = ''
+
+    if File.directory?(plugins)
+      # Get a list of all plugins + versions
+      Dir.entries(plugins).select do |plugin|
+        if (File.directory?("#{plugins}/#{plugin}") == true) && !(plugin == '..' || plugin == '.')
+          begin
+            contents = File.read("#{plugins}/#{plugin}/META-INF/MANIFEST.MF")
+            contents =~ (/Plugin\-Version:\s+([\d\.]+)/)
+            version = $1
+            jenkins_plugins = "#{plugin} #{version}, " + jenkins_plugins
+          rescue
+            # Nothing really to do about it, failing means no version which will
+            # result in a new plugin if needed
+          end
+        end
       end
     end
+
+    jenkins_plugins
   end
-  Facter.add('jenkins_plugins') do
-    setcode do
-      jenkins_plugins
-    end
-  end
-else
-  # Does not have jenkins installed
 end


### PR DESCRIPTION
Confining this fact required moving the conditional and variables inside the `setcode` block, however the overall logic of the fact is unchanged. This change also includes the recent patch 7c03e35ce4f5d2c7a112142cf58cb714f95dff02

I've tested this on Linux Jenkins box, and on a Windows box and it's working as expected.
