### PR TITLE
Support setting the slave mode

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -33,6 +33,9 @@
 # [*slave_home*]
 #   Defaults to '/home/jenkins-slave'.  This is where the code will be installed, and the workspace will end up.
 #
+# [*slave_mode*]
+#   Defaults to 'normal'. Can be either 'normal' (utilize this slave as much as possible) or 'exclusive' (leave this machine for tied jobs only).
+#
 # [*labels*]
 #   Not required.  Single string of whitespace-separated list of labels to be assigned for this slave.
 #
@@ -65,6 +68,7 @@ class jenkins::slave (
   $slave_user        = 'jenkins-slave',
   $slave_uid         = undef,
   $slave_home        = '/home/jenkins-slave',
+  $slave_mode        = 'normal',
   $labels            = undef,
   $install_java      = $jenkins::params::install_java,
   $enable            = true

--- a/templates/jenkins-slave.erb
+++ b/templates/jenkins-slave.erb
@@ -15,7 +15,7 @@ LOCK_FILE=/var/lock/jenkins-slave
 
 slave_start() {
   echo Starting Jenkins Slave...
-  runuser - <%= @slave_user -%> -c 'java -jar <%= @slave_home -%>/<%= @client_jar -%> <%= @ui_user_flag -%> <%= @ui_pass_flag -%> -name <%= @fqdn -%> -executors <%= @executors -%> <%= @masterurl_flag -%> <%= @labels_flag -%> &'
+  runuser - <%= @slave_user -%> -c 'java -jar <%= @slave_home -%>/<%= @client_jar -%> <%= @ui_user_flag -%> <%= @ui_pass_flag -%> -mode <%= @slave_mode -%> -name <%= @fqdn -%> -executors <%= @executors -%> <%= @masterurl_flag -%> <%= @labels_flag -%> &'
   pgrep -f -u <%= @slave_user -%> <%= @client_jar -%> > $PID_FILE
   RETVAL=$?
   [ $RETVAL -eq 0 ] && touch $LOCK_FILE


### PR DESCRIPTION
Add support for the 'mode' parameter for jenkins slaves:

"The mode controlling how Jenkins allocates jobs to slaves. Can be either 'normal' (utilize this slave as much as possible) or 'exclusive' (leave this machine for tied jobs only). Default is normal."
