### PR TITLE
set necessary mode on jenkins folders

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -21,6 +21,7 @@ define jenkins::plugin($version=0) {
         ensure  => directory,
         owner   => 'jenkins',
         group   => 'jenkins',
+        mode    => 755,
         require => [Group['jenkins'], User['jenkins']];
     }
   }


### PR DESCRIPTION
puppet will set default mode if nothing is set. Since jenkins needs to write in its home and plugin_dir - mode needs to be set to allow this
