### PR TITLE
make private classes private, dont pass params

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -4,18 +4,21 @@
 #
 class jenkins::cli {
 
+  if $caller_module_name != $module_name {
+    fail("Use of private class ${name} by ${caller_module_name}")
+  }
+
   $jar = '/usr/lib/jenkins/jenkins-cli.jar'
   $extract_jar = 'unzip /usr/lib/jenkins/jenkins.war WEB-INF/jenkins-cli.jar'
   $move_jar = "mv WEB-INF/jenkins-cli.jar ${jar}"
   $remove_dir = 'rm -rf WEB-INF'
 
-  exec {
-    'jenkins-cli' :
-      command => "${extract_jar} && ${move_jar} && ${remove_dir}",
-      path    => ['/bin', '/usr/bin'],
-      cwd     => '/tmp',
-      creates => $jar,
-      require => Package['jenkins'];
+  exec { 'jenkins-cli' :
+    command => "${extract_jar} && ${move_jar} && ${remove_dir}",
+    path    => ['/bin', '/usr/bin'],
+    cwd     => '/tmp',
+    creates => $jar,
+    require => Package['jenkins'],
   }
 
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,13 +10,15 @@
 #   }
 # }
 #
-class jenkins::config(
-  $config_hash = {},
-) {
+class jenkins::config {
+
+  if $caller_module_name != $module_name {
+    fail("Use of private class ${name} by ${caller_module_name}")
+  }
 
   include jenkins::package
 
   Class['Jenkins::Package']->Class['Jenkins::Config']
-  create_resources( 'jenkins::sysconfig', $config_hash )
+  create_resources( 'jenkins::sysconfig', $::jenkins::config_hash )
 }
 

--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -2,15 +2,17 @@
 # jenkins::firewall class integrates with the puppetlabs-firewall module for
 # opening the port to Jenkins automatically
 #
-class jenkins::firewall(
-  $port = 8080
-) {
-  firewall {
-    '500 allow Jenkins inbound traffic':
-      action => 'accept',
-      state  => 'NEW',
-      dport  => [$port],
-      proto  => 'tcp',
+class jenkins::firewall {
+
+  if $caller_module_name != $module_name {
+    fail("Use of private class ${name} by ${caller_module_name}")
+  }
+
+  firewall { '500 allow Jenkins inbound traffic':
+    action => 'accept',
+    state  => 'NEW',
+    dport  => [$::jenkins::port],
+    proto  => 'tcp',
   }
 }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,8 +74,8 @@ class jenkins(
   $repo               = $jenkins::params::repo,
   $service_enable     = $jenkins::params::service_enable,
   $service_ensure     = $jenkins::params::service_ensure,
-  $config_hash        = undef,
-  $plugin_hash        = undef,
+  $config_hash        = {},
+  $plugin_hash        = {},
   $configure_firewall = undef,
   $install_java       = $jenkins::params::install_java,
   $proxy_host         = undef,
@@ -84,6 +84,7 @@ class jenkins(
 ) inherits jenkins::params {
 
   validate_bool($lts, $install_java, $repo)
+  validate_hash($config_hash, $plugin_hash)
 
   if $configure_firewall {
     validate_bool($configure_firewall)
@@ -102,22 +103,14 @@ class jenkins(
     class {'jenkins::repo':}
   }
 
-  class {'jenkins::package' :
-    version => $version;
-  }
+  class {'jenkins::package': }
 
-  class { 'jenkins::config':
-    config_hash => $config_hash,
-  }
+  class { 'jenkins::config': }
 
-  class { 'jenkins::plugins':
-    plugin_hash => $plugin_hash,
-  }
+  class { 'jenkins::plugins': }
 
-  if $proxy_host {
+  if $proxy_host and $proxy_port {
     class { 'jenkins::proxy':
-      host    => $proxy_host,
-      port    => $proxy_port,
       require => Package['jenkins'],
       notify  => Service['jenkins']
     }

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -6,5 +6,6 @@ class jenkins::master (
 ) inherits jenkins::params {
 
   jenkins::plugin {'swarm':
-    version => $version }
+    version => $version ,
+  }
 }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -4,9 +4,13 @@
 #
 # The package might not specify a dependency on Java, so you may need to
 # specify that yourself
-class jenkins::package($version = 'installed') {
-  package {
-    'jenkins' :
-      ensure => $version;
+class jenkins::package {
+
+  if $caller_module_name != $module_name {
+    fail("Use of private class ${name} by ${caller_module_name}")
+  }
+
+  package { 'jenkins' :
+    ensure => $::jenkins::version;
   }
 }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -1,7 +1,10 @@
 #
 #
 #
-define jenkins::plugin($version=0) {
+define jenkins::plugin(
+  $version=0
+) {
+
   $plugin            = "${name}.hpi"
   $plugin_dir        = '/var/lib/jenkins/plugins'
   $plugin_parent_dir = inline_template('<%= @plugin_dir.split(\'/\')[0..-2].join(\'/\') %>')
@@ -16,37 +19,33 @@ define jenkins::plugin($version=0) {
   }
 
   if (!defined(File[$plugin_dir])) {
-    file {
-      [$plugin_parent_dir, $plugin_dir]:
-        ensure  => directory,
-        owner   => 'jenkins',
-        group   => 'jenkins',
-        mode    => '0755',
-        require => [Group['jenkins'], User['jenkins']];
+    file { [$plugin_parent_dir, $plugin_dir]:
+      ensure  => directory,
+      owner   => 'jenkins',
+      group   => 'jenkins',
+      mode    => '0755',
+      require => [Group['jenkins'], User['jenkins']],
     }
   }
 
   if (!defined(Group['jenkins'])) {
-    group {
-      'jenkins' :
-        ensure  => present,
-        require => Package['jenkins'];
+    group { 'jenkins' :
+      ensure  => present,
+      require => Package['jenkins'],
     }
   }
 
   if (!defined(User['jenkins'])) {
-    user {
-      'jenkins' :
-        ensure  => present,
-        home    => $plugin_parent_dir,
-        require => Package['jenkins'];
+    user { 'jenkins' :
+      ensure  => present,
+      home    => $plugin_parent_dir,
+      require => Package['jenkins'],
     }
   }
 
   if (!defined(Package['wget'])) {
-    package {
-      'wget' :
-        ensure => present;
+    package { 'wget' :
+      ensure => present,
     }
   }
 
@@ -61,20 +60,18 @@ define jenkins::plugin($version=0) {
       }
     }
 
-    exec {
-      "download-${name}" :
-        command    => "rm -rf ${name} ${name}.* && wget --no-check-certificate ${base_url}${plugin}",
-        cwd        => $plugin_dir,
-        require    => [File[$plugin_dir], Package['wget']],
-        path       => ['/usr/bin', '/usr/sbin', '/bin'];
+    exec { "download-${name}" :
+      command    => "rm -rf ${name} ${name}.* && wget --no-check-certificate ${base_url}${plugin}",
+      cwd        => $plugin_dir,
+      require    => [File[$plugin_dir], Package['wget']],
+      path       => ['/usr/bin', '/usr/sbin', '/bin'],
     }
 
-    file {
-      "${plugin_dir}/${plugin}" :
-        require => Exec["download-${name}"],
-        owner   => 'jenkins',
-        mode    => '0644',
-        notify  => Service['jenkins'];
+    file { "${plugin_dir}/${plugin}" :
+      require => Exec["download-${name}"],
+      owner   => 'jenkins',
+      mode    => '0644',
+      notify  => Service['jenkins'],
     }
   }
 

--- a/manifests/plugins.pp
+++ b/manifests/plugins.pp
@@ -1,8 +1,11 @@
 # Class: jenkins::plugins
 #
-class jenkins::plugins (
-  $plugin_hash = {}
-) {
-  validate_hash( $plugin_hash )
-  create_resources('jenkins::plugin',$plugin_hash)
+class jenkins::plugins {
+
+  if $caller_module_name != $module_name {
+    fail("Use of private class ${name} by ${caller_module_name}")
+  }
+
+  create_resources('jenkins::plugin',$jenkins::plugin_hash)
+
 }

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -1,8 +1,9 @@
 #
-class jenkins::proxy (
-  $host = undef,
-  $port = undef,
-) {
+class jenkins::proxy {
+
+  if $caller_module_name != $module_name {
+    fail("Use of private class ${name} by ${caller_module_name}")
+  }
 
   file { '/var/lib/jenkins/proxy.xml':
     content => template('jenkins/proxy.xml.erb'),

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -3,6 +3,10 @@
 #
 class jenkins::repo {
 
+  if $caller_module_name != $module_name {
+    fail("Use of private class ${name} by ${caller_module_name}")
+  }
+
   if ( $::jenkins::repo ) {
     case $::osfamily {
 

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -2,6 +2,11 @@
 #
 class jenkins::repo::debian
 {
+
+  if $caller_module_name != $module_name {
+    fail("Use of private class ${name} by ${caller_module_name}")
+  }
+
   if $::jenkins::lts  {
     apt::source { 'jenkins':
       location    => 'http://pkg.jenkins-ci.org/debian-stable',
@@ -10,8 +15,8 @@ class jenkins::repo::debian
       key         => 'D50582E6',
       key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
       include_src => false,
-      }
     }
+  }
   else {
     apt::source { 'jenkins':
       location    => 'http://pkg.jenkins-ci.org/debian',

--- a/manifests/repo/el.pp
+++ b/manifests/repo/el.pp
@@ -3,12 +3,16 @@
 class jenkins::repo::el
 {
 
+  if $caller_module_name != $module_name {
+    fail("Use of private class ${name} by ${caller_module_name}")
+  }
+
   if $::jenkins::lts  {
     yumrepo {'jenkins':
       descr    => 'Jenkins',
       baseurl  => 'http://pkg.jenkins-ci.org/redhat-stable/',
       gpgcheck => 1,
-      gpgkey   => 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key'
+      gpgkey   => 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key',
     }
   }
 
@@ -17,7 +21,7 @@ class jenkins::repo::el
       descr    => 'Jenkins',
       baseurl  => 'http://pkg.jenkins-ci.org/redhat/',
       gpgcheck => 1,
-      gpgkey   => 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key'
+      gpgkey   => 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key',
     }
   }
 }

--- a/manifests/repo/suse.pp
+++ b/manifests/repo/suse.pp
@@ -3,21 +3,23 @@
 class jenkins::repo::suse
 {
 
+  if $caller_module_name != $module_name {
+    fail("Use of private class ${name} by ${caller_module_name}")
+  }
+
   if $::jenkins::lts {
     zypprepo {'jenkins':
       descr    => 'Jenkins',
       baseurl  => 'http://pkg.jenkins-ci.org/opensuse-stable/',
       gpgcheck => 1,
-      gpgkey   => 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key'
+      gpgkey   => 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key',
     }
-  }
-
-  else {
+  } else {
     zypprepo {'jenkins':
       descr    => 'Jenkins',
       baseurl  => 'http://pkg.jenkins-ci.org/opensuse/',
       gpgcheck => 1,
-      gpgkey   => 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key'
+      gpgkey   => 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key',
     }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,11 +1,17 @@
 # Class: jenkins::service
 #
 class jenkins::service {
+
+  if $caller_module_name != $module_name {
+    fail("Use of private class ${name} by ${caller_module_name}")
+  }
+
   service { 'jenkins':
     ensure     => $jenkins::service_ensure,
     enable     => $jenkins::service_enable,
     hasstatus  => true,
     hasrestart => true,
   }
+
 }
 

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -79,7 +79,7 @@ class jenkins::slave (
 
   if $install_java {
     class {'java':
-      distribution => 'jdk'
+      distribution => 'jdk',
     }
   }
 
@@ -92,7 +92,7 @@ class jenkins::slave (
       comment    => 'Jenkins Slave user',
       home       => $slave_home,
       managehome => true,
-      uid        => $slave_uid
+      uid        => $slave_uid,
     }
   }
 
@@ -111,7 +111,7 @@ class jenkins::slave (
     path         => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
     user         => $slave_user,
     #refreshonly => true,
-    creates      => "${slave_home}/${client_jar}"
+    creates      => "${slave_home}/${client_jar}",
     ## needs to be fixed if you create another version..
   }
 

--- a/manifests/sysconfig.pp
+++ b/manifests/sysconfig.pp
@@ -1,6 +1,7 @@
 # Class: jenkins::sysconfig
 #
 define jenkins::sysconfig ( $value ) {
+
   $path = $::osfamily ? {
     RedHat  => '/etc/sysconfig',
     Suse  => '/etc/sysconfig',
@@ -14,5 +15,6 @@ define jenkins::sysconfig ( $value ) {
     match   => "^${name}=",
     notify  => Service['jenkins'],
   }
+
 }
 

--- a/spec/classes/jenkins_cli_spec.rb
+++ b/spec/classes/jenkins_cli_spec.rb
@@ -1,8 +1,18 @@
 require 'spec_helper'
 
-describe 'jenkins::cli' do
+describe 'jenkins' do
+  let(:facts) { { :osfamily => 'RedHat', :operatingsystem => 'RedHat' } }
 
+  context 'cli' do
+    context 'default' do
+      it { should_not contain_class('jenkins::cli') }
+    end
+
+    context '$cli => true' do
+      let(:params) { { :cli => true } }
       it { should create_class('jenkins::cli') }
       it { should contain_exec('jenkins-cli') }
+    end
+  end
 
 end

--- a/spec/classes/jenkins_config_spec.rb
+++ b/spec/classes/jenkins_config_spec.rb
@@ -1,8 +1,17 @@
 require 'spec_helper'
 
-describe 'jenkins::config' do
+describe 'jenkins' do
+  let(:facts) { { :osfamily => 'RedHat', :operatingsystem => 'RedHat' } }
 
-  # Ensure compilation
-  it { should create_class('jenkins::config') }
+  context 'config' do
+    context 'default' do
+      it { should contain_class('jenkins::config') }
+    end
+
+    context 'create config' do
+      let(:params) { { :config_hash => { 'AJP_PORT' => { 'value' => '1234' } } }}
+      it { should contain_jenkins__sysconfig('AJP_PORT') }
+    end
+  end
 
 end

--- a/spec/classes/jenkins_firewall_spec.rb
+++ b/spec/classes/jenkins_firewall_spec.rb
@@ -1,10 +1,11 @@
 require 'spec_helper'
 
-describe 'jenkins::firewall' do
+describe 'jenkins' do
+  let(:facts) { { :osfamily => 'RedHat', :operatingsystem => 'RedHat' } }
+  let(:pre_condition) { "define firewall($action, $state, $dport, $proto) {}" }
+  let(:params) { { :configure_firewall => true } }
 
-  describe 'with firewall' do
-    let(:pre_condition) { "define firewall($action, $state, $dport, $proto) {}" }
-#    pending "not sure how to implement this"
+  context 'firewall' do
     it { should contain_firewall('500 allow Jenkins inbound traffic') }
   end
 

--- a/spec/classes/jenkins_package_spec.rb
+++ b/spec/classes/jenkins_package_spec.rb
@@ -1,7 +1,17 @@
 require 'spec_helper'
 
-describe 'jenkins::package' do
+describe 'jenkins' do
+  let(:facts) { { :osfamily => 'RedHat', :operatingsystem => 'RedHat' } }
 
-  it { should contain_package('jenkins') }
+  describe 'package' do
+    context 'default' do
+      it { should contain_package('jenkins').with_installed }
+    end
+
+    context 'with version' do
+      let(:params) { { :version => '1.2.3' } }
+      it { should contain_package('jenkins').with_ensure('1.2.3') }
+    end
+  end
 
 end

--- a/spec/classes/jenkins_plugins_spec.rb
+++ b/spec/classes/jenkins_plugins_spec.rb
@@ -1,8 +1,18 @@
 require 'spec_helper'
 
-describe 'jenkins::plugins' do
+describe 'jenkins' do
+  let(:facts) { { :osfamily => 'RedHat', :operatingsystem => 'RedHat' } }
 
-  # Ensure compilation
-  it { should create_class('jenkins::plugins') }
+  context 'plugins' do
+    context 'default' do
+      it { should contain_class('jenkins::plugins') }
+    end
+
+    context 'install plugin' do
+      let(:params) { { :plugin_hash => { 'git' => { 'version' => '1.1.1' } } } }
+
+      it { should contain_jenkins__plugin('git').with_version('1.1.1') }
+    end
+  end
 
 end

--- a/spec/classes/jenkins_proxy_spec.rb
+++ b/spec/classes/jenkins_proxy_spec.rb
@@ -1,8 +1,21 @@
 require 'spec_helper'
 
-describe 'jenkins::proxy' do
+describe 'jenkins' do
+  let(:facts) { { :osfamily => 'RedHat', :operatingsystem => 'RedHat' } }
 
-  it { should create_class('jenkins::proxy') }
-  it { should contain_file('/var/lib/jenkins/proxy.xml') }
+  context 'proxy' do
+    context 'default' do
+      it { should_not contain_class('jenkins::proxy') }
+    end
+
+    context 'with proxy config' do
+      let(:params) { { :proxy_host => 'myhost', :proxy_port => 1234 } }
+      it { should create_class('jenkins::proxy') }
+      it { should contain_file('/var/lib/jenkins/proxy.xml') }
+      it { should contain_file('/var/lib/jenkins/proxy.xml').with(:content => /<name>myhost<\/name>/) }
+      it { should contain_file('/var/lib/jenkins/proxy.xml').with(:content => /<port>1234<\/port>/) }
+    end
+  end
 
 end
+

--- a/spec/classes/jenkins_repo_debian_spec.rb
+++ b/spec/classes/jenkins_repo_debian_spec.rb
@@ -1,22 +1,26 @@
 require 'spec_helper'
 
-describe 'jenkins::repo::debian' do
+describe 'jenkins' do
 
   # Switching OS Family to prevent duplicate declaration
   let(:facts) do
     {
-      :osfamily => 'Ubuntu',
+      :osfamily => 'Debian',
       :lsbdistcodename => 'precise',
-      :lsbdistid => 'ubuntu'
+      :lsbdistid => 'ubuntu',
+      :operatingsystem => 'Debian'
     }
   end
 
-  describe 'default' do
-    it { should contain_apt__source('jenkins').with_location('http://pkg.jenkins-ci.org/debian') }
+  context 'repo::debian' do
+    describe 'default' do
+      it { should contain_apt__source('jenkins').with_location('http://pkg.jenkins-ci.org/debian') }
+    end
+
+    describe 'lts = true' do
+      let(:params) { { :lts => true } }
+      it { should contain_apt__source('jenkins').with_location('http://pkg.jenkins-ci.org/debian-stable') }
+    end
   end
 
-  describe 'lts = true' do
-    let(:pre_condition) { ['class jenkins { $lts = true }', 'include jenkins'] }
-    it { should contain_apt__source('jenkins').with_location('http://pkg.jenkins-ci.org/debian-stable') }
-  end
 end

--- a/spec/classes/jenkins_repo_el_spec.rb
+++ b/spec/classes/jenkins_repo_el_spec.rb
@@ -1,16 +1,18 @@
 require 'spec_helper'
 
-describe 'jenkins::repo::el' do
+describe 'jenkins' do
   # Switching OS Family to prevent duplicate declaration
   let(:facts) { { :osfamily => 'Redhat', :operatingsystem => 'CentOS' } }
 
-  describe 'default' do
-    it { should contain_yumrepo('jenkins').with_baseurl('http://pkg.jenkins-ci.org/redhat/') }
-  end
+  context 'repo::el' do
+    describe 'default' do
+      it { should contain_yumrepo('jenkins').with_baseurl('http://pkg.jenkins-ci.org/redhat/') }
+    end
 
-  describe 'lts = true' do
-    let(:pre_condition) { ['class jenkins { $lts = true }', 'include jenkins'] }
-    it { should contain_yumrepo('jenkins').with_baseurl('http://pkg.jenkins-ci.org/redhat-stable/') }
+    describe 'lts = true' do
+      let(:params) { { :lts => true } }
+      it { should contain_yumrepo('jenkins').with_baseurl('http://pkg.jenkins-ci.org/redhat-stable/') }
+    end
   end
 
 end

--- a/spec/classes/jenkins_repo_spec.rb
+++ b/spec/classes/jenkins_repo_spec.rb
@@ -1,39 +1,51 @@
 require 'spec_helper'
 
-describe 'jenkins::repo' do
+describe 'jenkins' do
 
-  describe 'default' do
-    let(:pre_condition) { ['class jenkins { $repo = true }', 'include jenkins'] }
-    describe 'RedHat' do
-      let(:facts) { { :osfamily => 'RedHat' } }
-      it { should contain_class('jenkins::repo::el') }
+  describe 'repo' do
+    describe 'default' do
+      describe 'RedHat' do
+        let(:facts) { { :osfamily => 'RedHat', :operatingsystem => 'CentOs' } }
+        it { should contain_class('jenkins::repo::el') }
+        it { should_not contain_class('jenkins::repo::suse') }
+        it { should_not contain_class('jenkins::repo::debian') }
+      end
+
+      describe 'Linux' do
+        let(:facts) { { :osfamily => 'Linux' } }
+        let(:params) { { :install_java => false } }
+        it { should contain_class('jenkins::repo::el') }
+        it { should_not contain_class('jenkins::repo::suse') }
+        it { should_not contain_class('jenkins::repo::debian') }
+      end
+
+      describe 'Suse' do
+        let(:facts) { { :osfamily => 'Suse', :operatingsystem => 'OpenSuSE' } }
+        it { should contain_class('jenkins::repo::suse') }
+        it { should_not contain_class('jenkins::repo::el') }
+        it { should_not contain_class('jenkins::repo::debian') }
+      end
+
+      describe 'Debian' do
+        let(:facts) { { :osfamily => 'Debian', :lsbdistid => 'debian', :lsbdistcodename => 'natty', :operatingsystem => 'Debian' } }
+        it { should contain_class('jenkins::repo::debian') }
+        it { should_not contain_class('jenkins::repo::suse') }
+        it { should_not contain_class('jenkins::repo::el') }
+      end
+
+      describe 'Unknown' do
+        let(:facts) { { :osfamily => 'SomethingElse', :operatingsystem => 'RedHat' } }
+        it { expect { should raise_error(Puppet::Error) } }
+      end
     end
 
-    describe 'Linux' do
-      let(:facts) { { :osfamily => 'Linux' } }
-      it { should contain_class('jenkins::repo::el') }
+    describe 'repo => false' do
+      let(:facts) { { :osfamily => 'RedHat', :operatingsystem => 'CentOs' } }
+      let(:params) { { :repo => false } }
+      it { should_not contain_class('jenkins::repo') }
+      it { should_not contain_class('jenkins::repo::el') }
+      it { should_not contain_class('jenkins::repo::suse') }
+      it { should_not contain_class('jenkins::repo::debian') }
     end
-
-    describe 'Suse' do
-      let(:facts) { { :osfamily => 'Suse' } }
-      it { should contain_class('jenkins::repo::suse') }
-    end
-
-    describe 'Debian' do
-      let(:facts) { { :osfamily => 'Debian', :lsbdistid => 'debian' } }
-      it { should contain_class('jenkins::repo::debian') }
-    end
-
-    describe 'Unknown' do
-      let(:facts) { { :osfamily => 'SomethingElse' } }
-      it { expect { should raise_error(Puppet::Error) } }
-    end
-  end
-
-  describe 'repo = 0' do
-    let(:pre_condition) { ['class jenkins { $repo = false }', 'include jenkins'] }
-    it { should_not contain_class('jenkins::repo::el') }
-    it { should_not contain_class('jenkins::repo::suse') }
-    it { should_not contain_class('jenkins::repo::debian') }
   end
 end

--- a/spec/classes/jenkins_repo_suse_spec.rb
+++ b/spec/classes/jenkins_repo_suse_spec.rb
@@ -1,16 +1,18 @@
 require 'spec_helper'
 
-describe 'jenkins::repo::suse' do
+describe 'jenkins' do
   # Switching OS Family to prevent duplicate declaration
-  let(:facts) { { :osfamily => 'Suse' } }
+  let(:facts) { { :osfamily => 'Suse', :operatingsystem => 'OpenSuSE' } }
 
-  describe 'default' do
-    it { should contain_zypprepo('jenkins').with_baseurl('http://pkg.jenkins-ci.org/opensuse/') }
-  end
+  context 'repo::suse' do
+    describe 'default' do
+      it { should contain_zypprepo('jenkins').with_baseurl('http://pkg.jenkins-ci.org/opensuse/') }
+    end
 
-  describe 'lts = true' do
-    let(:pre_condition) { ['class jenkins { $lts = true }', 'include jenkins'] }
-    it { should contain_zypprepo('jenkins').with_baseurl('http://pkg.jenkins-ci.org/opensuse-stable/') }
+    describe 'lts = true' do
+      let(:params) { { :lts => true } }
+      it { should contain_zypprepo('jenkins').with_baseurl('http://pkg.jenkins-ci.org/opensuse-stable/') }
+    end
   end
 
 end

--- a/spec/classes/jenkins_service_spec.rb
+++ b/spec/classes/jenkins_service_spec.rb
@@ -1,7 +1,17 @@
 require 'spec_helper'
 
-describe 'jenkins::service' do
+describe 'jenkins' do
+  let(:facts) { { :osfamily => 'RedHat', :operatingsystem => 'RedHat' } }
 
-  it { should contain_service('jenkins') }
+  context 'service' do
+    context 'default' do
+      it { should contain_service('jenkins').with(:ensure => 'running', :enable => true) }
+    end
+
+    context 'managing service' do
+      let(:params) { { :service_ensure => 'stopped', :service_enable => false } }
+      it { should contain_service('jenkins').with(:ensure => 'stopped', :enable => false ) }
+    end
+  end
 
 end

--- a/spec/classes/jenkins_spec.rb
+++ b/spec/classes/jenkins_spec.rb
@@ -7,6 +7,7 @@ describe 'jenkins' do
     let(:facts) do
       { :osfamily => 'RedHat', :operatingsystem => 'CentOS' }
     end
+
     describe 'default' do
       it { should contain_class 'jenkins' }
       it { should contain_class 'java' }
@@ -32,69 +33,37 @@ describe 'jenkins' do
       it { should_not contain_class 'jenkins::repo' }
     end
 
-    describe 'with proxy host' do
+    describe 'with only proxy host' do
       let(:params) { { :proxy_host => '1.2.3.4' } }
+      it { should_not contain_class('jenkins::proxy') }
+    end
+
+    describe 'with only proxy_port' do
+      let(:params) { { :proxy_port => 1234 } }
+      it { should_not contain_class('jenkins::proxy') }
+    end
+
+    describe 'with proxy_host and proxy_port' do
+      let(:params) { { :proxy_host => '1.2.3.4', :proxy_port => 1234 } }
       it { should contain_class 'jenkins::proxy'}
     end
 
-    describe 'with firewall manage' do
+    describe 'with firewall, configure_firewall => true' do
       let(:pre_condition) { 'define firewall ($action, $state, $dport, $proto) {}' }
       let(:params) { { :configure_firewall => true } }
       it { should contain_class 'jenkins::firewall' }
     end
 
-    describe 'with firewall dont manage' do
+    describe 'with firewall, configure_firewall => false' do
       let(:pre_condition) { 'define firewall ($action, $state, $dport, $proto) {}' }
       let(:params) { { :configure_firewall => false } }
       it { should_not contain_class 'jenkins::firewall' }
     end
 
-    describe 'with firewall configure unset' do
+    describe 'with firewall, configure_firewall unset' do
       let(:pre_condition) { 'define firewall ($action, $state, $dport, $proto) {}' }
       it { expect { should raise_error(Puppet::Error) } }
     end
 
-  end
-
-  describe "on Suse" do
-    let(:facts) do
-      { :osfamily => 'Suse'}
-    end
-    describe 'default' do
-      it { should contain_class 'jenkins::repo' }
-      it { should contain_class 'jenkins::repo::suse' }
-      it { should_not contain_class 'jenkins::repo::debian' }
-      it { should_not contain_class 'jenkins::repo::el' }
-    end
-  end
-
-  describe "on Debian" do
-    let(:facts) do
-      { :osfamily => 'Debian', :lsbdistcodename => 'precise' }
-    end
-    let :pre_condition do
-      " define apt::source (
-          $location          = '',
-          $release           = $lsbdistcodename,
-          $repos             = 'main',
-          $include_src       = true,
-          $required_packages = false,
-          $key               = false,
-          $key_server        = 'keyserver.ubuntu.com',
-          $key_content       = false,
-          $key_source        = false,
-          $pin               = false
-        ) {
-          notify { 'mock apt::source $title':; }
-        }
-      "
-    end
-
-    describe 'default' do
-      it { should contain_class 'jenkins::repo' }
-      it { should contain_class 'jenkins::repo::debian' }
-      it { should_not contain_class 'jenkins::repo::el' }
-      it { should_not contain_class 'jenkins::repo::suse' }
-    end
   end
 end

--- a/templates/proxy.xml.erb
+++ b/templates/proxy.xml.erb
@@ -1,4 +1,4 @@
 <proxy>
-  <name><%= @host %></name>
-  <port><%= @port %></port>
+  <name><%= scope.lookupvar('::jenkins::proxy_host') %></name>
+  <port><%= scope.lookupvar('::jenkins::proxy_port') %></port>
 </proxy>


### PR DESCRIPTION
It is very difficult to test at the subclass level to ensure parameters set at the main class are passed correctly to the subclass, especially when the subclass has defaults of it's own.  I have made the mistake numerous times of setting a subclass parameter and all of the tests succeed but I forgot to actually pass the value from the main class.

This PR removes parameter passing and pulls all variables directly from the main class.
Spec tests are updated to ensure subclasses behave as they should based on parameters to the main class
OS dependent testing removed from main spec, no OS dependent decisions are made there
Minor bug fixes
Minor lint cleanup
