### PR TITLE
Fix dependency issues between repo setup and package installation

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -2,20 +2,32 @@
 # jenkins::repo handles pulling in the platform specific repo classes
 #
 class jenkins::repo {
+  include stdlib
+  anchor { 'jenkins::repo::begin': }
+  anchor { 'jenkins::repo::end': }
 
   if ( $::jenkins::repo ) {
     case $::osfamily {
 
       'RedHat', 'Linux': {
         class { 'jenkins::repo::el': }
+        Anchor['jenkins::repo::begin'] ->
+          Class['jenkins::repo::el'] ->
+          Anchor['jenkins::repo::end']
       }
 
       'Debian': {
         class { 'jenkins::repo::debian': }
+        Anchor['jenkins::repo::begin'] ->
+          Class['jenkins::repo::debian'] ->
+          Anchor['jenkins::repo::end']
       }
 
       'Suse' : {
         class { 'jenkins::repo::suse': }
+        Anchor['jenkins::repo::begin'] ->
+          Class['jenkins::repo::suse'] ->
+          Anchor['jenkins::repo::end']
       }
 
       default: {

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -2,6 +2,8 @@
 #
 class jenkins::repo::debian
 {
+  include stdlib
+
   if $::jenkins::lts  {
     apt::source { 'jenkins':
       location    => 'http://pkg.jenkins-ci.org/debian-stable',
@@ -22,6 +24,10 @@ class jenkins::repo::debian
       include_src => false,
     }
   }
+
+  anchor { 'jenkins::repo::debian::begin': } ->
+    Apt::Source['jenkins'] ->
+    anchor { 'jenkins::repo::debian::end': }
 }
 
 


### PR DESCRIPTION
Fix dependency issues between repo configuration and package installation (makes sure repo configuration is finished before installing packages). Classes containing other classes need to use the anchor pattern to ensure this (see http://docs.puppetlabs.com/puppet/2.7/reference/lang_containment.html and http://projects.puppetlabs.com/issues/8040 for details).
