### PR TITLE
Fix grep bug when plugin version specified

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -8,7 +8,7 @@ define jenkins::plugin($version=0) {
 
   if ($version != 0) {
     $base_url = "http://updates.jenkins-ci.org/download/plugins/${name}/${version}/"
-    $search   = "${name} ${version},"
+    $search   = "${name} ${version}(,|$)"
   }
   else {
     $base_url = 'http://updates.jenkins-ci.org/latest/'

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -26,6 +26,22 @@ describe 'jenkins::plugin' do
     it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
   end
 
+  describe 'with version and in middle of jenkins_plugins fact' do
+    let(:params) { { :version => '1.2.3' } }
+    let(:facts) { { :jenkins_plugins => 'myplug 1.2.3, fooplug 1.4.5' } }
+
+    it { should_not contain_exec('download-myplug') }
+    it { should_not contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
+  end
+
+  describe 'with version and at end of jenkins_plugins fact' do
+    let(:params) { { :version => '1.2.3' } }
+    let(:facts) { { :jenkins_plugins => 'fooplug 1.4.5, myplug 1.2.3' } }
+
+    it { should_not contain_exec('download-myplug') }
+    it { should_not contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
+  end
+
   describe 'with proxy' do
     let(:pre_condition) { [
       'class jenkins {


### PR DESCRIPTION
- The jenkins::plugin fact is a comma separated string of plugins. When
  a plugin version is specified, the string to search is:
  'myplugin 1.2.3,'
  
  However, the last plugin in the jenkins::plugin fact doesn't end with
  a comma. This results in that plugin not being found by grep() and so
  puppet tries to install the plugin on each run.
  
  Adding a simple regex alternation checking for comma or end-of-string
  (,|$) fixes this.
- Added test cases.
