### PR TITLE
Ensure jenkins.repo is deleted if repo is not used. (As the official RPM...

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -9,4 +9,11 @@ class jenkins::package($version = 'installed') {
     'jenkins' :
       ensure => $version;
   }
+
+  if $jenkins::repo == false {
+    file {
+      '/etc/yum.repos.d/jenkins.repo' :
+        ensure => absent;
+    }
+  }
 }


### PR DESCRIPTION
Ensure jenkins.repo is deleted if repo is set to false. (As the official RPM package deploy/install jenkins.repo)
As we use an internal repository (satellite) we don't want the jenkins.repo file deploy during install.
