### PR TITLE
Add daemon install to Debian family slave installs

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -157,6 +157,11 @@ class jenkins::slave (
         owner   => 'root',
         group   => 'root',
         content => template("${module_name}/jenkins-slave-defaults.${::osfamily}"),
+        require => Package['daemon'],
+      }
+
+      package { 'daemon':
+        ensure => present,
       }
     }
     default: {


### PR DESCRIPTION
`daemon` is utilized in the init script, and the script will not work by default on debian or ubuntu. 
Just tested using http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-7.2.0_chef-provisionerless.box, which is a totally clean debian weezy install. 
