### PR TITLE
fix firewall

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -125,13 +125,12 @@ class jenkins(
 
   class {'jenkins::service':}
 
-  if defined('::firewall') {
-    if $configure_firewall == undef {
-      fail('The firewall module is included in your manifests, please configure $configure_firewall in the jenkins module')
-    } elsif $configure_firewall {
-      class {'jenkins::firewall':}
+  if $configure_firewall != undef {
+    if defined('::firewall') {
+      class {'jenkins::firewall':} 
     }
   }
+
   if $cli {
     class {'jenkins::cli':}
   }


### PR DESCRIPTION
$ configure_firewall is enabled and only if the class firewall exists
It is desirable to perform
