### PR TITLE
Support updates for core jenkins modules

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -69,6 +69,17 @@ define jenkins::plugin(
       }
     }
 
+    # create a pinned file if the plugin has a .jpi extension
+    #   to override the builtin module versions
+    exec { "create-pinnedfile-${name}" :
+      command => "touch ${plugin_dir}/${name}.jpi.pinned",
+      cwd     => $plugin_dir,
+      require => File[$plugin_dir],
+      path    => ['/usr/bin', '/usr/sbin', '/bin'],
+      onlyif  => "test -f ${plugin_dir}/${name}.jpi -a ! -f ${plugin_dir}/${name}.jpi.pinned",
+      before  => Exec["download-${name}"],
+    }
+
     exec { "download-${name}" :
       command    => "rm -rf ${name} ${name}.* && wget --no-check-certificate ${base_url}${plugin}",
       cwd        => $plugin_dir,


### PR DESCRIPTION
This fixes https://github.com/jenkinsci/puppet-jenkins/issues/118 and will (should) not break existing configurations. If the extension of the updated module is '.jpi', then put a .pinned file in the plugins folder before installing the updated module.
