### PR TITLE
Added in ability for user to redefine update center plugin URL

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -11,6 +11,7 @@ define jenkins::plugin(
   $manage_config   = false,
   $config_filename = undef,
   $config_content  = undef,
+  $update_url = "http://updates.jenkins-ci.org/download/plugins",
 ) {
 
   $plugin            = "${name}.hpi"
@@ -19,7 +20,7 @@ define jenkins::plugin(
   validate_bool ($manage_config)
 
   if ($version != 0) {
-    $base_url = "http://updates.jenkins-ci.org/download/plugins/${name}/${version}/"
+    $base_url = "${update_url}/${name}/${version}/"
     $search   = "${name} ${version}(,|$)"
   }
   else {


### PR DESCRIPTION
Jenkins update centre can be unreliable with some plugin downloads. Hence we here add in the ability for a user to redefine the update centre plugin URL.
