### PR TITLE
Use single-quotes to avoid problems with slave labels

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -144,7 +144,7 @@ class jenkins::slave (
   }
 
   if $labels {
-    $labels_flag = "-labels \"${labels}\""
+    $labels_flag = "-labels \'${labels}\'"
   } else {
     $labels_flag = ''
   }


### PR DESCRIPTION
If you are using more than one label for your slave, the debian/ubuntu init-script will fail. Using single-quotes fixes the problem.

```
root@myhost:~# /etc/init.d/jenkins-slave stop
/etc/default/jenkins-slave: line 37: mylabel: command not found

 * Stopping Jenkins Slave Swarm Client jenkins-slave               
```
