### PR TITLE
Ensure future parser compatibility (>3.5.1)

### DIFF
--- a/manifests/sysconfig.pp
+++ b/manifests/sysconfig.pp
@@ -3,10 +3,10 @@
 define jenkins::sysconfig ( $value ) {
 
   $path = $::osfamily ? {
-    RedHat  => '/etc/sysconfig',
-    Suse  => '/etc/sysconfig',
-    Debian  => '/etc/default',
-    default => fail( "Unsupported OSFamily ${::osfamily}" )
+    'RedHat' => '/etc/sysconfig',
+    'Suse'   => '/etc/sysconfig',
+    'Debian' => '/etc/default',
+    default  => fail( "Unsupported OSFamily ${::osfamily}" )
   }
 
   file_line { "Jenkins sysconfig setting ${name}":


### PR DESCRIPTION
Since Puppet 3.5.1 the future parser no longer matches upper case words in a selector statement as they are treated as a custom resource type.

See https://tickets.puppetlabs.com/browse/PUP-2800?focusedCommentId=76016&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-76016 for details.
