### PR TITLE
Add defined check for plugin_parent_dir resource

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -28,13 +28,25 @@ define jenkins::plugin(
   }
 
   if (!defined(File[$plugin_dir])) {
-    file { [$plugin_parent_dir, $plugin_dir]:
+
+    if (!defined(File[$plugin_parent_dir])) {
+      file { $plugin_parent_dir:
+        ensure  => directory,
+        owner   => 'jenkins',
+        group   => 'jenkins',
+        mode    => '0755',
+        require => [Group['jenkins'], User['jenkins']],
+      }
+    }
+
+    file { $plugin_dir:
       ensure  => directory,
       owner   => 'jenkins',
       group   => 'jenkins',
       mode    => '0755',
       require => [Group['jenkins'], User['jenkins']],
     }
+
   }
 
   if (!defined(Group['jenkins'])) {


### PR DESCRIPTION
The management of the basic dependencies of a Jenkins plugin should not
be unnecessarily forced on the user. This change wraps the plugin_parent_dir
resource creation in a `defined` function to allow the user to create the
Jenkins home directory themselves if necessary.

The use case for this would be a simple symbolic link resource that would link 
the default `/var/lib/jenkins` parent directory to another location for storage 
space, or other system reasons.

This fixes #148 in a more backwards compatible way than #149.
