### PR TITLE
Add slave service notification when defaults file changes

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -172,6 +172,7 @@ class jenkins::slave (
         owner   => 'root',
         group   => 'root',
         content => template("${module_name}/jenkins-slave-defaults.${::osfamily}"),
+        notify  => Service['jenkins-slave'],
         require => Package['daemon'],
       }
 


### PR DESCRIPTION
This fixes an issue where if a slave's Debian defaults file changes, the slave process is never notified of the change and requires a manual restart.
