### PR TITLE
bump up default version of swarm client

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,7 @@ class jenkins::params {
   $service_enable     = true
   $service_ensure     = 'running'
   $install_java       = true
-  $swarm_version      = '1.9'
+  $swarm_version      = '1.16'
 }
 
 


### PR DESCRIPTION
A recent version of the swarm client is necessary to avoid compatibility issues with newer Jenkins
versions (e.g. see https://issues.jenkins-ci.org/browse/JENKINS-20138). I also ran into very weird issues with the Git plug-in on my slaves.

This patch bumps up the default version of the swarm client that gets installed.
