### PR TITLE
Allow setting the slave name, default to the fqdn at runtime

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -8,6 +8,9 @@
 #
 # === Parameters
 #
+# [*slave_name*]
+#   Specify the name of the slave.  Not required, by default it will use the fqdn.
+#
 # [*masterurl*]
 #   Specify the URL of the master server.  Not required, the plugin will do a UDP autodiscovery. If specified, the autodiscovery will be skipped.
 #
@@ -62,6 +65,7 @@
 #
 # Copyright 2013 Matthew Barr , but can be used for anything by anyone..
 class jenkins::slave (
+  $slave_name               = undef,
   $masterurl                = undef,
   $ui_user                  = undef,
   $ui_pass                  = undef,

--- a/spec/classes/jenkins_slave_spec.rb
+++ b/spec/classes/jenkins_slave_spec.rb
@@ -9,6 +9,7 @@ describe 'jenkins::slave' do
     it { should contain_user('jenkins-slave_user').with_uid(nil) }
     # Let the different platform blocks define  `slave_runtime_file` separately below
     it { should contain_file(slave_runtime_file).with_content(/-fsroot \/home\/jenkins-slave/) }
+    it { should contain_file(slave_runtime_file).without_content(/ -name /) }
 
     describe 'with ssl verification disabled' do
       let(:params) { { :disable_ssl_verification => true } }
@@ -32,6 +33,11 @@ describe 'jenkins::slave' do
     let(:slave_runtime_file) { '/etc/init.d/jenkins-slave' }
 
     it_behaves_like 'a jenkins::slave catalog'
+
+    describe 'with slave_name' do
+      let(:params) { { :slave_name => 'jenkins-slave' } }
+      it { should contain_file(slave_runtime_file).with_content(/ -name jenkins-slave /) }
+    end
   end
 
   describe 'Debian' do
@@ -39,6 +45,12 @@ describe 'jenkins::slave' do
     let(:slave_runtime_file) { '/etc/default/jenkins-slave' }
 
     it_behaves_like 'a jenkins::slave catalog'
+
+    describe 'with slave_name' do
+      let(:params) { { :slave_name => 'jenkins-slave' } }
+      it { should contain_file(slave_runtime_file).with_content(/^CLIENT_NAME=jenkins-slave$/) }
+      it { should contain_file(slave_runtime_file).with_content(/ -name \$CLIENT_NAME /) }
+    end
   end
 
   describe 'Unknown' do

--- a/templates/jenkins-slave-defaults.Debian
+++ b/templates/jenkins-slave-defaults.Debian
@@ -40,7 +40,7 @@ MASTER_URL="<%= @masterurl_flag -%> <%= @labels_flag -%>"
 
 EXECUTORS=<%= @executors -%>
 
-CLIENT_NAME=<%= @fqdn -%>
+<%= "CLIENT_NAME=#{@slave_name}" if @slave_name -%>
 
 
-JENKINS_SLAVE_ARGS="<%= @ui_user_flag -%> <%= @ui_pass_flag -%> -name $CLIENT_NAME <%= @disable_ssl_verification_flag -%> -executors $EXECUTORS $MASTER_URL <%= @fsroot_flag -%>"
+JENKINS_SLAVE_ARGS="<%= @ui_user_flag -%> <%= @ui_pass_flag -%><%= " -name $CLIENT_NAME" if @slave_name -%> <%= @disable_ssl_verification_flag -%> -executors $EXECUTORS $MASTER_URL <%= @fsroot_flag -%>"

--- a/templates/jenkins-slave.erb
+++ b/templates/jenkins-slave.erb
@@ -19,7 +19,7 @@ fi
 
 slave_start() {
   echo Starting Jenkins Slave...
-  $RUNUSER - <%= @slave_user -%> -c 'java -jar <%= @slave_home -%>/<%= @client_jar -%> <%= @ui_user_flag -%> <%= @ui_pass_flag -%> -mode <%= @slave_mode -%> -name <%= @fqdn || @hostname -%> -executors <%= @executors -%> <%= @masterurl_flag -%> <%= @labels_flag -%> <%= @disable_ssl_verification_flag -%>  <%= @fsroot_flag -%>  &'
+  $RUNUSER - <%= @slave_user -%> -c 'java -jar <%= @slave_home -%>/<%= @client_jar -%> <%= @ui_user_flag -%> <%= @ui_pass_flag -%> -mode <%= @slave_mode -%><%= " -name #{@slave_name}" if @slave_name -%> -executors <%= @executors -%> <%= @masterurl_flag -%> <%= @labels_flag -%> <%= @disable_ssl_verification_flag -%>  <%= @fsroot_flag -%>  &'
   pgrep -f -u <%= @slave_user -%> <%= @client_jar -%> > $PID_FILE
   RETVAL=$?
   [ $RETVAL -eq 0 ] && touch $LOCK_FILE


### PR DESCRIPTION
Running the jar without name will automatically use the fqdn as name
so no need to set it to the fqdn, and it's a problem when building images
as the name is preset for any instance.
