### PR TITLE
Fix puppet lint errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rake', '>= 10.1.1'
 gem 'rspec', '~> 2.99.0'
-gem 'puppet-lint', '>= 0.3.2'
+gem 'puppet-lint', '>= 0.3.2', '< 1.0.0'
 gem 'rspec-puppet', '>= 1.0.1'
 gem 'puppetlabs_spec_helper', '>= 0.4.1'
 gem 'puppet-syntax', '>= 1.1.0'

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -70,10 +70,10 @@ define jenkins::plugin(
     }
 
     exec { "download-${name}" :
-      command    => "rm -rf ${name} ${name}.* && wget --no-check-certificate ${base_url}${plugin}",
-      cwd        => $plugin_dir,
-      require    => [File[$plugin_dir], Package['wget']],
-      path       => ['/usr/bin', '/usr/sbin', '/bin'],
+      command => "rm -rf ${name} ${name}.* && wget --no-check-certificate ${base_url}${plugin}",
+      cwd     => $plugin_dir,
+      require => [File[$plugin_dir], Package['wget']],
+      path    => ['/usr/bin', '/usr/sbin', '/bin'],
     }
 
     file { "${plugin_dir}/${plugin}" :

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -118,11 +118,11 @@ class jenkins::slave (
   }
 
   exec { 'get_swarm_client':
-    command      => "wget -O ${slave_home}/${client_jar} ${client_url}/${client_jar}",
-    path         => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
-    user         => $slave_user,
+    command => "wget -O ${slave_home}/${client_jar} ${client_url}/${client_jar}",
+    path    => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
+    user    => $slave_user,
     #refreshonly => true,
-    creates      => "${slave_home}/${client_jar}",
+    creates => "${slave_home}/${client_jar}",
     ## needs to be fixed if you create another version..
   }
 

--- a/manifests/sysconfig.pp
+++ b/manifests/sysconfig.pp
@@ -10,10 +10,10 @@ define jenkins::sysconfig ( $value ) {
   }
 
   file_line { "Jenkins sysconfig setting ${name}":
-    path    => "${path}/jenkins",
-    line    => "${name}=\"${value}\"",
-    match   => "^${name}=",
-    notify  => Service['jenkins'],
+    path   => "${path}/jenkins",
+    line   => "${name}=\"${value}\"",
+    match  => "^${name}=",
+    notify => Service['jenkins'],
   }
 
 }


### PR DESCRIPTION
They make the build fail when using puppet-lint 1.0.0+
