### PR TITLE
Fix lint in puppet-lint 1.0.0+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rake', '>= 10.1.1'
 gem 'rspec', '~> 2.99.0'
-gem 'puppet-lint', '>= 0.3.2', '< 1.0.0'
+gem 'puppet-lint', '>= 0.3.2'
 gem 'rspec-puppet', '>= 1.0.1'
 gem 'puppetlabs_spec_helper', '>= 0.4.1'
 gem 'puppet-syntax', '>= 1.1.0'

--- a/Rakefile
+++ b/Rakefile
@@ -17,4 +17,5 @@ PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send("disable_80chars")
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')
 PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetLint.configuration.relative = true
 PuppetSyntax.exclude_paths = exclude_paths


### PR DESCRIPTION
With the fix lint can be upgraded to 1.0.0, removes workaround from #167
