### PR TITLE
jenkins::slave fails to refresh the service

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -172,6 +172,7 @@ class jenkins::slave (
         owner   => 'root',
         group   => 'root',
         content => template("${module_name}/jenkins-slave-defaults.${::osfamily}"),
+        notify  => Service['jenkins-slave'],
         require => Package['daemon'],
       }
 


### PR DESCRIPTION
Fixing bug: if the settings of the class jenkins::slave change, the file '/etc/default/jenkins-slave' will be updated and the service jenkins-slave should to be notified.
