### PR TITLE
Allow setting the slave name, default to the fqdn at runtime

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -8,6 +8,9 @@
 #
 # === Parameters
 #
+# [*slave_name*]
+#   Specify the name of the slave.  Not required, by default it will use the fqdn.
+#
 # [*masterurl*]
 #   Specify the URL of the master server.  Not required, the plugin will do a UDP autodiscovery. If specified, the autodiscovery will be skipped.
 #
@@ -62,6 +65,7 @@
 #
 # Copyright 2013 Matthew Barr , but can be used for anything by anyone..
 class jenkins::slave (
+  $slave_name               = undef,
   $masterurl                = undef,
   $ui_user                  = undef,
   $ui_pass                  = undef,

--- a/spec/classes/jenkins_slave_spec.rb
+++ b/spec/classes/jenkins_slave_spec.rb
@@ -9,6 +9,7 @@ describe 'jenkins::slave' do
     it { should contain_user('jenkins-slave_user').with_uid(nil) }
     # Let the different platform blocks define  `slave_runtime_file` separately below
     it { should contain_file(slave_runtime_file).with_content(/^FSROOT="\/home\/jenkins-slave"$/) }
+    it { should contain_file(slave_runtime_file).without_content(/ -name /) }
 
     describe 'with ssl verification disabled' do
       let(:params) { { :disable_ssl_verification => true } }
@@ -32,11 +33,20 @@ describe 'jenkins::slave' do
     end
   end
 
+  shared_examples 'using slave_name' do
+    it { should contain_file(slave_runtime_file).with_content(/^CLIENT_NAME="jenkins-slave"$/) }
+  end
+
   describe 'RedHat' do
     let(:facts) { { :osfamily => 'RedHat', :operatingsystem => 'CentOS' } }
     let(:slave_runtime_file) { '/etc/sysconfig/jenkins-slave' }
 
     it_behaves_like 'a jenkins::slave catalog'
+
+    describe 'with slave_name' do
+      let(:params) { { :slave_name => 'jenkins-slave' } }
+      it_behaves_like 'using slave_name'
+    end
   end
 
   describe 'Debian' do
@@ -44,6 +54,11 @@ describe 'jenkins::slave' do
     let(:slave_runtime_file) { '/etc/default/jenkins-slave' }
 
     it_behaves_like 'a jenkins::slave catalog'
+
+    describe 'with slave_name' do
+      let(:params) { { :slave_name => 'jenkins-slave' } }
+      it_behaves_like 'using slave_name'
+    end
   end
 
   describe 'Unknown' do

--- a/templates/jenkins-slave-defaults.erb
+++ b/templates/jenkins-slave-defaults.erb
@@ -45,7 +45,7 @@ LABELS="<%= @labels -%>"
 
 EXECUTORS=<%= @executors -%>
 
-CLIENT_NAME="<%= @fqdn -%>"
+CLIENT_NAME="<%= @slave_name -%>"
 
 FSROOT="<%= @slave_home -%>"
 


### PR DESCRIPTION
Running the jar without name will automatically use the fqdn as name
so no need to set it to the fqdn, and it's a problem when building images
as the name is preset for any instance.
