### PR TITLE
Fix installation of core plugins

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -92,7 +92,7 @@ define jenkins::plugin(
     }
 
     exec { "download-${name}" :
-      command => "rm -rf ${name} ${name}.* && wget --no-check-certificate ${base_url}${plugin}",
+      command => "rm -rf ${name} ${name}.hpi ${name}.jpi && wget --no-check-certificate ${base_url}${plugin}",
       cwd     => $plugin_dir,
       require => [File[$plugin_dir], Package['wget']],
       path    => ['/usr/bin', '/usr/sbin', '/bin'],

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -25,7 +25,7 @@ describe 'jenkins::plugin' do
 
   describe 'without version' do
     it { should contain_exec('download-myplug').with(
-      :command      => 'rm -rf myplug myplug.* && wget --no-check-certificate http://updates.jenkins-ci.org/latest/myplug.hpi',
+      :command      => 'rm -rf myplug myplug.hpi myplug.jpi && wget --no-check-certificate http://updates.jenkins-ci.org/latest/myplug.hpi',
       :environment  => nil
     )}
     it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}


### PR DESCRIPTION
This prevents the 'plugin.jpi.pinned' file
from being deleted.
Otherwise Jenkins always starts to manage the plugin by itself.

See #118 #131
