### PR TITLE
set default port for firewall

### DIFF
--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -8,10 +8,16 @@ class jenkins::firewall {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
+  if $::jenkins::config_hash and has_key($::jenkins::config_hash, 'HTTP_PORT') {
+    $http_port = $::jenkins::config_hash['HTTP_PORT']
+  } else {
+    $http_port = '8080'
+  }
+
   firewall { '500 allow Jenkins inbound traffic':
     action => 'accept',
     state  => 'NEW',
-    dport  => [$::jenkins::port],
+    dport  => [$http_port],
     proto  => 'tcp',
   }
 }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -134,3 +134,4 @@ define jenkins::plugin(
     }
   }
 }
+


### PR DESCRIPTION
Since port parameter seems to be missing from init.pp, use the same logic to determin it as in cli_helper.pp
