### PR TITLE
Fix for #174 allows setting $jenkins::port

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,9 @@
 # lts = true
 #   Use LTS verison of jenkins
 #
+# port = 8080 (default)
+#   Sets firewall port to 8080 if puppetlabs-firewall module is installed
+#
 # repo = true (Default)
 #   install the jenkins repo.
 #
@@ -109,6 +112,7 @@ class jenkins(
   $proxy_port         = undef,
   $no_proxy_list      = undef,
   $cli                = undef,
+  $port               = $jenkins::params::port,
   $libdir             = $jenkins::params::libdir,
 ) inherits jenkins::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class jenkins::params {
   $install_java               = true
   $swarm_version              = '1.17'
   $default_plugins_host       = 'http://updates.jenkins-ci.org'
+  $port                       = '8080'
 
   case $::osfamily {
     'Debian': {


### PR DESCRIPTION
When used with strict variables turned on, firewall.pp expects
$jenkins::port to be set. Overriding in hiera will not correct as it's
still an undefined variable in code. This fix allows port to be set and
provides a default in params.pp
