### PR TITLE
Fix bug in cli.pp that tries to exec without full qualified path

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -34,6 +34,7 @@ class jenkins::cli {
   # Reload all Jenkins config from disk (only when notified)
   exec { 'reload-jenkins':
     command     => "${cmd} reload-configuration",
+    path        => ['/bin', '/usr/bin'],
     tries       => 10,
     try_sleep   => 2,
     refreshonly => true,
@@ -43,6 +44,7 @@ class jenkins::cli {
   # Do a safe restart of Jenkins (only when notified)
   exec { 'safe-restart-jenkins':
     command     => "${cmd} safe-restart && /bin/sleep 10",
+    path        => ['/bin', '/usr/bin'],
     tries       => 10,
     try_sleep   => 2,
     refreshonly => true,


### PR DESCRIPTION
When adding a user it gave me the following error: 

Error: Validation of Exec[safe-restart-jenkins] failed: 'java -jar /usr/share/jenkins/jenkins-cli.jar -s http://localhost:8080 safe-restart && /bin/sleep 10' is not qualified and no path was specified. Please qualify the command or specify a path. at /etc/puppet/modules/jenkins/manifests/cli.pp:51

This patch fixes that error.
