### PR TITLE
Jenkins slave defaults bugfix

### DIFF
--- a/templates/jenkins-slave-defaults.erb
+++ b/templates/jenkins-slave-defaults.erb
@@ -76,7 +76,7 @@ if [ -n "$FSROOT" ]; then
   FSROOT_ARG="-fsroot '$FSROOT'"
 fi
 
-if [-n "$AUTO_DISCOVERY_ADDRESS" ]; then
+if [ -n "$AUTO_DISCOVERY_ADDRESS" ]; then
   AUTO_DISCOVERY_ADDRESS_ARG="-autoDiscoveryAddress '$AUTO_DISCOVERY_ADDRESS'"
 fi
 


### PR DESCRIPTION
This was causing an issue during slave process restart on CentOS7, resulting in the following:

```
[root@slave ~]# systemctl status jenkins-slave.service
jenkins-slave.service - SYSV: Jenkins Slave Swarm Client
   Loaded: loaded (/etc/rc.d/init.d/jenkins-slave)
   Active: failed (Result: exit-code) since Thu 2014-12-18 08:19:23 UTC; 1min 17s ago
  Process: 27562 ExecStop=/etc/rc.d/init.d/jenkins-slave stop (code=exited, status=0/SUCCESS)
  Process: 27569 ExecStart=/etc/rc.d/init.d/jenkins-slave start (code=exited, status=1/FAILURE)

Dec 18 08:19:23 slave.host systemd[1]: Starting SYSV: Jenkins Slave Swarm Client...
Dec 18 08:19:23 slave.host jenkins-slave[27569]: /etc/sysconfig/jenkins-slave: line 75: [-n: command not found
Dec 18 08:19:23 slave.host jenkins-slave[27569]: Starting Jenkins Slave...
Dec 18 08:19:23 slave.host systemd[1]: jenkins-slave.service: control process exited, code=exited status=1
Dec 18 08:19:23 slave.host systemd[1]: Failed to start SYSV: Jenkins Slave Swarm Client.
Dec 18 08:19:23 slave.host systemd[1]: Unit jenkins-slave.service entered failed state.
```
