### PR TITLE
Add "basic" support for OpenBSD. 

### DIFF
--- a/lib/puppet/jenkins.rb
+++ b/lib/puppet/jenkins.rb
@@ -4,7 +4,11 @@ module Puppet
     # @return [String] Full path to the Jenkins user's home directory
     def self.home_dir
       begin
-        return File.expand_path('~jenkins')
+        if Facter.value(:osfamily) == 'OpenBSD'
+          return File.expand_path('~_jenkins')
+        else
+          return File.expand_path('~jenkins')
+        end
       rescue ArgumentError
         # The Jenkins user doesn't exist!
         return nil
@@ -13,7 +17,11 @@ module Puppet
 
     # @return [String] Full path to the Jenkins user's plugin directory
     def self.plugins_dir
-      return File.join(self.home_dir, 'plugins')
+      if Facter.value(:osfamily) == 'OpenBSD'
+        return File.join(self.home_dir, '.jenkins', 'plugins')
+      else
+        return File.join(self.home_dir, 'plugins')
+      end
     end
   end
 end

--- a/lib/puppet/jenkins/facts.rb
+++ b/lib/puppet/jenkins/facts.rb
@@ -13,7 +13,7 @@ module Puppet
       # @return [NilClass]
       def self.install
         Facter.add(:jenkins_plugins) do
-          confine :kernel => [ "Linux", "OpenBSD" ]
+          confine :kernel => [ 'Linux', 'OpenBSD' ]
           setcode do
             Puppet::Jenkins::Facts.plugins_str
           end

--- a/lib/puppet/jenkins/facts.rb
+++ b/lib/puppet/jenkins/facts.rb
@@ -13,7 +13,7 @@ module Puppet
       # @return [NilClass]
       def self.install
         Facter.add(:jenkins_plugins) do
-          confine :kernel => 'Linux'
+          confine :kernel => [ "Linux", "OpenBSD" ]
           setcode do
             Puppet::Jenkins::Facts.plugins_str
           end

--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -23,7 +23,7 @@ class jenkins::cli {
       Anchor['jenkins::end']
 
   $jar = "${jenkins::libdir}/jenkins-cli.jar"
-  $extract_jar = "$::jenkins::jarbin -xf ${jenkins::libdir}/jenkins.war WEB-INF/jenkins-cli.jar"
+  $extract_jar = "${::jenkins::jarbin} -xf ${jenkins::libdir}/jenkins.war WEB-INF/jenkins-cli.jar"
   $move_jar = "mv WEB-INF/jenkins-cli.jar ${jar}"
   $remove_dir = 'rm -rf WEB-INF'
 

--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -23,7 +23,7 @@ class jenkins::cli {
       Anchor['jenkins::end']
 
   $jar = "${jenkins::libdir}/jenkins-cli.jar"
-  $extract_jar = "jar -xf ${jenkins::libdir}/jenkins.war WEB-INF/jenkins-cli.jar"
+  $extract_jar = "$::jenkins::jarbin -xf ${jenkins::libdir}/jenkins.war WEB-INF/jenkins-cli.jar"
   $move_jar = "mv WEB-INF/jenkins-cli.jar ${jar}"
   $remove_dir = 'rm -rf WEB-INF'
 
@@ -53,7 +53,7 @@ class jenkins::cli {
   # The jenkins cli command with required parameter(s)
   $cmd = join(
     delete_undef_values([
-      'java',
+      $::jenkins::javabin,
       "-jar ${::jenkins::cli::jar}",
       "-s http://localhost:${port}${prefix}",
       $auth_arg,

--- a/manifests/cli/config.pp
+++ b/manifests/cli/config.pp
@@ -56,8 +56,8 @@ class jenkins::cli::config(
         # the owner/group should probably be set externally and retrieved if
         # present in the manfiest. At present, there is no authoritative place
         # to retrive this information from.
-        owner => 'jenkins',
-        group => 'jenkins',
+        owner => $::jenkins::user,
+        group => $::jenkins::group,
       }
     }
   }

--- a/manifests/cli_helper.pp
+++ b/manifests/cli_helper.pp
@@ -48,7 +48,7 @@ class jenkins::cli_helper (
 
   $helper_cmd = join(
     delete_undef_values([
-      '/usr/bin/java',
+      $::jenkins::javabin,
       "-jar ${::jenkins::cli::jar}",
       "-s http://127.0.0.1:${port}${prefix}",
       $auth_arg,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,10 @@
 # service_ensure = 'running' (default)
 #   Status of the jenkins service.  running, stopped
 #
+# service_flags = undef (default)
+#   Service parameters for the jenkins service on OpenBSD, string, see daemon_flags
+#   in /etc/rc.d/jenkins for an example.
+#
 # config_hash = undef (Default)
 #   Hash with config options to set in sysconfig/jenkins defaults/jenkins
 #
@@ -53,6 +57,14 @@
 #
 # executors = undef (Default)
 #   Integer number of executors on the Jenkin's master.
+#
+# jarbin = 'jar' (Default system dependent)
+#   short or full path to the Java 'jar' binary. Full path necessary for systems
+#   where it is not in the default PATH, otherwise short path.
+#
+# javabin = 'java' (Default system dependent)
+#   short or full path to the Java 'java' binary. Full path necessary for systems
+#   where it is not in the default PATH, otherwise short path.
 #
 # slaveagentport = undef (Default)
 #   Integer number of portnumber for the slave agent.
@@ -163,11 +175,6 @@
 #   - Accepts input as array only.
 #   - Only effective if "proxy_host" and "proxy_port" are set.
 #
-# user = 'jenkins' (default)
-#
-# group = 'jenkins' (default)
-#
-#
 class jenkins(
   $version            = $jenkins::params::version,
   $lts                = $jenkins::params::lts,
@@ -179,6 +186,7 @@ class jenkins(
   $service_enable     = $jenkins::params::service_enable,
   $service_ensure     = $jenkins::params::service_ensure,
   $service_provider   = $jenkins::params::service_provider,
+  $service_flags      = undef,
   $config_hash        = {},
   $plugin_hash        = {},
   $job_hash           = {},
@@ -198,6 +206,8 @@ class jenkins(
   $manage_datadirs    = $jenkins::params::manage_datadirs,
   $localstatedir      = $::jenkins::params::localstatedir,
   $executors          = undef,
+  $jarbin             = $::jenkins::params::jarbin,
+  $javabin            = $::jenkins::params::javabin,
   $slaveagentport     = undef,
   $manage_user        = $::jenkins::params::manage_user,
   $user               = $::jenkins::params::user,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,21 +19,28 @@ class jenkins::params {
   $package_name          = 'jenkins'
 
   $manage_datadirs = true
-  $localstatedir   = '/var/lib/jenkins'
 
   $manage_user  = true
-  $user         = 'jenkins'
   $manage_group = true
-  $group        = 'jenkins'
 
   case $::osfamily {
     'Debian': {
+      $user             = 'jenkins'
+      $group            = 'jenkins'
+      $jarbin           = 'jar'
+      $javabin          = 'java'
       $libdir           = '/usr/share/jenkins'
+      $localstatedir    = '/var/lib/jenkins'
       $package_provider = 'dpkg'
       $service_provider = undef
     }
     'RedHat': {
+      $user             = 'jenkins'
+      $group            = 'jenkins'
+      $jarbin           = 'jar'
+      $javabin          = 'java'
       $libdir           = '/usr/lib/jenkins'
+      $localstatedir    = '/var/lib/jenkins'
       $package_provider = 'rpm'
       case $::operatingsystem {
         'Fedora': {
@@ -51,8 +58,22 @@ class jenkins::params {
         }
       }
     }
+    'OpenBSD': {
+      $user             = '_jenkins'
+      $group            = '_jenkins'
+      $jarbin           = '/usr/local/jdk-1.8.0/bin/jar'
+      $javabin          = '/usr/local/jdk-1.8.0/bin/java'
+      $libdir           = '/usr/local/share/jenkins'
+      $localstatedir    = '/var/jenkins'
+      $package_provider = 'openbsd'
+    }
     default: {
+      $user             = 'jenkins'
+      $group            = 'jenkins'
+      $jarbin           = 'jar'
+      $javabin          = 'java'
       $libdir           = '/usr/lib/jenkins'
+      $localstatedir    = '/var/lib/jenkins'
       $package_provider = undef
       $service_provider = undef
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -64,7 +64,7 @@ class jenkins::params {
       $jarbin           = '/usr/local/jdk-1.8.0/bin/jar'
       $javabin          = '/usr/local/jdk-1.8.0/bin/java'
       $libdir           = '/usr/local/share/jenkins'
-      $localstatedir    = '/var/jenkins'
+      $localstatedir    = '/var/jenkins/.jenkins'
       $package_provider = 'openbsd'
     }
     default: {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -33,6 +33,7 @@ class jenkins::repo {
           Class['jenkins::repo::suse'] ->
           Anchor['jenkins::repo::end']
       }
+      'OpenBSD' : { }
 
       default: {
         fail( "Unsupported OS family: ${::osfamily}" )

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,12 +6,26 @@ class jenkins::service {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  service { 'jenkins':
-    ensure     => $jenkins::service_ensure,
-    enable     => $jenkins::service_enable,
-    provider   => $jenkins::service_provider,
-    hasstatus  => true,
-    hasrestart => true,
+  case $::osfamily  {
+    'OpenBSD': {
+        service { 'jenkins':
+          ensure     => $jenkins::service_ensure,
+          enable     => $jenkins::service_enable,
+          provider   => $jenkins::service_provider,
+          flags      => $jenkins::service_flags,
+          hasstatus  => true,
+          hasrestart => true,
+        }
+    }
+    default: {
+      service { 'jenkins':
+        ensure     => $jenkins::service_ensure,
+        enable     => $jenkins::service_enable,
+        provider   => $jenkins::service_provider,
+        hasstatus  => true,
+        hasrestart => true,
+      }
+    }
   }
 
 }

--- a/manifests/sysconfig.pp
+++ b/manifests/sysconfig.pp
@@ -6,17 +6,20 @@ define jenkins::sysconfig(
   validate_string($value)
 
   $path = $::osfamily ? {
-    'RedHat' => '/etc/sysconfig',
-    'Suse'   => '/etc/sysconfig',
-    'Debian' => '/etc/default',
-    default  => fail( "Unsupported OSFamily ${::osfamily}" )
+    'RedHat'  => '/etc/sysconfig',
+    'Suse'    => '/etc/sysconfig',
+    'Debian'  => '/etc/default',
+    'OpenBSD' => undef,
+    default   => fail( "Unsupported OSFamily ${::osfamily}" )
   }
 
-  file_line { "Jenkins sysconfig setting ${name}":
-    path   => "${path}/jenkins",
-    line   => "${name}=\"${value}\"",
-    match  => "^${name}=",
-    notify => Service['jenkins'],
+  if $path {
+    file_line { "Jenkins sysconfig setting ${name}":
+      path   => "${path}/jenkins",
+      line   => "${name}=\"${value}\"",
+      match  => "^${name}=",
+      notify => Service['jenkins'],
+    }
   }
 
 }

--- a/spec/classes/jenkins_config_spec.rb
+++ b/spec/classes/jenkins_config_spec.rb
@@ -9,15 +9,29 @@ describe 'jenkins', :type => :module do
       :operatingsystemmajrelease => '6',
     }
   end
+    context 'config' do
+      context 'default' do
+        it { should contain_class('jenkins::config') }
+      end
 
-  context 'config' do
-    context 'default' do
-      it { should contain_class('jenkins::config') }
+      context 'create config' do
+        let(:params) { { :config_hash => { 'AJP_PORT' => { 'value' => '1234' } } }}
+        it { should contain_jenkins__sysconfig('AJP_PORT').with_value('1234') }
+      end
     end
-
-    context 'create config' do
-      let(:params) { { :config_hash => { 'AJP_PORT' => { 'value' => '1234' } } }}
-      it { should contain_jenkins__sysconfig('AJP_PORT').with_value('1234') }
+  end
+  context 'on OpenBSD' do
+    let(:facts) { { :osfamily => 'OpenBSD', :operatingsystem => 'OpenBSD' } }
+    context 'config' do
+      context 'default' do
+        it { should contain_class('jenkins::config') }
+      end
+      context 'create config' do
+        let(:params) { { :config_hash => { 'AJP_PORT' => { 'value' => '1234' } } }}
+        it 'should fail' do
+          expect { should compile }.to raise_error
+        end
+      end
     end
   end
 

--- a/spec/classes/jenkins_config_spec.rb
+++ b/spec/classes/jenkins_config_spec.rb
@@ -1,14 +1,15 @@
 require 'spec_helper'
 
 describe 'jenkins', :type => :module do
-  let(:facts) do
-    {
-      :osfamily                  => 'RedHat',
-      :operatingsystem           => 'RedHat',
-      :operatingsystemrelease    => '6.7',
-      :operatingsystemmajrelease => '6',
-    }
-  end
+  context 'on RedHat' do
+    let(:facts) do
+      {
+        :osfamily                  => 'RedHat',
+        :operatingsystem           => 'RedHat',
+        :operatingsystemrelease    => '6.7',
+        :operatingsystemmajrelease => '6',
+      }
+    end
     context 'config' do
       context 'default' do
         it { should contain_class('jenkins::config') }
@@ -20,6 +21,7 @@ describe 'jenkins', :type => :module do
       end
     end
   end
+
   context 'on OpenBSD' do
     let(:facts) { { :osfamily => 'OpenBSD', :operatingsystem => 'OpenBSD' } }
     context 'config' do

--- a/spec/classes/jenkins_repo_spec.rb
+++ b/spec/classes/jenkins_repo_spec.rb
@@ -32,6 +32,13 @@ describe 'jenkins', :type => :module do
         it { should_not contain_class('jenkins::repo::el') }
       end
 
+      describe 'OpenBSD' do
+        let(:facts) { { :osfamily => 'OpenBSD' } }
+        it { should_not contain_class('jenkins::repo::el') }
+        it { should_not contain_class('jenkins::repo::suse') }
+        it { should_not contain_class('jenkins::repo::debian') }
+      end
+
       describe 'Unknown' do
         let(:facts) { { :osfamily => 'SomethingElse', :operatingsystem => 'RedHat' } }
         it { expect { should raise_error(Puppet::Error) } }

--- a/spec/classes/jenkins_service_spec.rb
+++ b/spec/classes/jenkins_service_spec.rb
@@ -32,4 +32,14 @@ describe 'jenkins', :type => :module  do
     end
   end
 
+  context 'non default service_flags on OpenBSD' do
+    let(:facts) { { :osfamily => 'OpenBSD', :operatingsystem => 'OpenBSD' } }
+    let(:params) { { :service_flags => 'myflags' } }
+    it { should contain_service('jenkins').with(:flags => 'myflags') }
+  end
+  context 'service_flags set on not OpenBSD OS' do
+    let(:facts) { { :osfamily => 'RedHat', :operatingsystem => 'RedHat' } }
+    let(:params) { { :service_flags => 'myflags' } }
+    it { should_not contain_service('jenkins').with(:flags => 'myflags') }
+  end
 end

--- a/spec/defines/jenkins_cli_exec_spec.rb
+++ b/spec/defines/jenkins_cli_exec_spec.rb
@@ -12,7 +12,7 @@ describe 'jenkins::cli::exec', :type => :define do
     }
   end
 
-  let(:helper_cmd) { '/usr/bin/java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://127.0.0.1:8080 groovy /usr/lib/jenkins/puppet_helper.groovy' }
+  let(:helper_cmd) { 'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://127.0.0.1:8080 groovy /usr/lib/jenkins/puppet_helper.groovy' }
 
   describe 'relationships' do
     it do

--- a/spec/unit/facter/plugins_spec.rb
+++ b/spec/unit/facter/plugins_spec.rb
@@ -48,20 +48,22 @@ describe Puppet::Jenkins::Facts do
       Puppet::Jenkins::Facts.install
     end
 
-    context 'on Linux' do
-      let(:kernel) { 'Linux' }
+    ['Linux', 'OpenBSD'].each do |kernel|
+      context "on #{kernel}" do
+        let(:kernel) { kernel }
 
-      context 'with no plugins' do
-        it { should be_nil }
-      end
-
-      context 'with plugins' do
-        let(:plugins_str) { 'ant 1.2, git 2.0.1' }
-        before :each do
-          Jenkins::Facts::Plugins.should_receive(:plugins).and_return(plugins_str)
+        context 'with no plugins' do
+          it { should be_nil }
         end
 
-        it { should eql(plugins_str) }
+        context 'with plugins' do
+          let(:plugins_str) { 'ant 1.2, git 2.0.1' }
+          before :each do
+            Jenkins::Facts::Plugins.should_receive(:plugins).and_return(plugins_str)
+          end
+
+          it { should eql(plugins_str) }
+        end
       end
     end
 

--- a/spec/unit/jenkins_plugins_spec.rb
+++ b/spec/unit/jenkins_plugins_spec.rb
@@ -3,6 +3,11 @@ require 'puppet/jenkins/plugins'
 
 describe Puppet::Jenkins::Plugins do
   describe '.exists?' do
+    let(:facts) do
+      {
+        :osfamily                  => 'RedHat',
+      }
+    end
     subject(:exists) { described_class.exists? }
 
     context 'if jenkins does not exist' do

--- a/spec/unit/jenkins_spec.rb
+++ b/spec/unit/jenkins_spec.rb
@@ -14,13 +14,18 @@ describe Puppet::Jenkins do
     end
 
     context 'when a jenkins user does exist' do
-      let(:home) { '/rspec/jenkins' }
+      ['RedHat', 'OpenBSD'].each do |osfamily|
+        context "On #{osfamily}" do
+          let(:facts) { { :osfamily => osfamily } }
+          let(:home) { '/rspec/jenkins' }
 
-      before :each do
-        File.should_receive(:expand_path).and_return(home)
+          before :each do
+            File.should_receive(:expand_path).and_return(home)
+          end
+
+          it { should eql home }
+        end
       end
-
-      it { should eql home }
     end
   end
 end


### PR DESCRIPTION
Support only "basic", since a few things are untested, and known to not work (yet).

What works and is tested:
- installation via package
- jenkins service management
- plugins_string fact and therefore plugin management

What is definately not working:
- jenkins::cli (jar is not in the PATH), I have to "enhance"
  puppetlabs/java before that, to add a fact pointing to the right
  directory, or add another variable to params.pp ;)

Otherwise untested:
- jobs management
- jenkins slave configuration

Some changes had to be done to the params.pp. Some information that
were hard-coded before, are now OS dependent set there. For all the
other OS, kept as it was there already, or somewhere else hard-coded.

On OpenBSD, and other *BSD, there is no group 'root', therefore, whereever
access permissions for a 'root' group were made, changed it to the gid of '0'

The jenkins system user and group are '_jenkins', therefore added these
as variables. Jenkins users home directory is /var/jenkins, instead of the
otherwise hardcoded /var/lib/jenkins, and further, jenkins is installed
in /var/lib/jenkins/.jenkins.

Because of above facts, most changes to manifests/plugins.pp, because the
plugin_parent_dir assumption, that this is the same as the jenkins users
home directory is not true on OpenBSD. Also, wget is available as package,
but installed in /usr/local/bin. Therefore added this to the path for the command.

Further, made repo management OS dependent, and for OpenBSD, set the value
to false.

Services on OpenBSD get configured via flags to the OpenBSD service provider.
Since I had seen problems with older Puppet versions, manifests/services got
a little bit enhanced, to only make use of that flag, when on OpenBSD.

Last but not least, a bunch of specs added here and there, to reflect OpenBSD.

Tested on OpenBSD amd64 with Puppet 3.7.4, jenkins-1.605 and jenkins-1.596.1, that is all available as packages.

haven't added OpenBSD to metadata.json, due to above mentioned bits that are not (yet ;) supported.

Hope that all that makes sense, and can be merged. Let me know if there is something that needs clarification, or changes or whatnot, and I'll be happy to work on it.

cheers.
