### PR TITLE
update rspec-puppet to ~> 2.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'rake', '>= 10.1.1'
 gem 'rspec-its'
 gem 'puppet-lint', '>= 0.3.2'
-gem 'rspec-puppet', '~> 2.1.0'
+gem 'rspec-puppet', '~> 2.3.0'
 gem 'puppetlabs_spec_helper',   :require => false
 gem 'puppet-syntax', '>= 1.1.0'
 gem 'json'

--- a/spec/functions/jenkins_port_spec.rb
+++ b/spec/functions/jenkins_port_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
-# Skip this example block under puppet-4 as it will fail with rspec-puppet
-# 2.1.0.
-#
-# https://github.com/rodjek/rspec-puppet/issues/282
-describe 'jenkins_port', :if => Puppet.version.to_f < 4.0 do
+describe 'jenkins_port' do
 
   let(:facts) { { :osfamily => 'RedHat', :operatingsystem => 'RedHat' } }
   let(:pre_condition) { 'include ::jenkins' }


### PR DESCRIPTION
Resolves the issue with function testing present in 2.1.0.  See:
https://github.com/rodjek/rspec-puppet/issues/282
