### PR TITLE
Adapt soon to be deprecated parameters (apt module)

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -11,22 +11,30 @@ class jenkins::repo::debian
 
   if $::jenkins::lts  {
     apt::source { 'jenkins':
-      location    => 'http://pkg.jenkins-ci.org/debian-stable',
-      release     => 'binary/',
-      repos       => '',
-      key         => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-      key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
-      include_src => false,
+      location => 'http://pkg.jenkins-ci.org/debian-stable',
+      release  => 'binary/',
+      repos    => '',
+      key      => {
+        'id'     => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+        'source' => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+      },
+      include  => {
+        'src' => false,
+      }
     }
   }
   else {
     apt::source { 'jenkins':
-      location    => 'http://pkg.jenkins-ci.org/debian',
-      release     => 'binary/',
-      repos       => '',
-      key         => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-      key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
-      include_src => false,
+      location => 'http://pkg.jenkins-ci.org/debian',
+      release  => 'binary/',
+      repos    => '',
+      key      => {
+        'id'     => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+        'source' => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+      },
+      include  => {
+        'src' => false,
+      }
     }
   }
 


### PR DESCRIPTION
Next major release of apt module will deprecate some parameters. They
were replaced by parameters that expect hashes.
