### PR TITLE
Symbolic link jobs folder

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,6 +19,7 @@ class jenkins::config {
     owner  => $::jenkins::user,
     group  => $::jenkins::group,
     mode   => '0755',
+    links  => follow,
   }
 
   # ensure_resource is used to try to maintain backwards compatiblity with

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -28,6 +28,7 @@ define jenkins::plugin(
   $pin             = true,
   # no worky
   $timeout         = undef,
+  $plugins_base    = 'download/plugins',
   # deprecated
   $plugin_dir      = undef,
   $username        = undef,
@@ -69,7 +70,7 @@ define jenkins::plugin(
       undef   => $::jenkins::default_plugins_host,
       default => $update_url,
     }
-    $base_url = "${plugins_host}/download/plugins/${name}/${version}/"
+    $base_url = "${plugins_host}/${plugins_base}/${name}/${version}/"
     # Escape +'s in $version when constructing $search.
     # * We can't use single quotes for the replacement string because
     #   puppet 3 and puppet 4 interpret '\\' differently.

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -199,6 +199,29 @@ describe 'jenkins::plugin' do
         include_examples 'execute the right fetch command'
       end
     end
+
+    context 'with a custom plugins_base' do
+      let(:plugins_base) { 'custom_plugins_base' }
+
+      context 'without a version' do
+        let(:params) { {:plugins_base => plugins_base} }
+        let(:expected_url) do
+          "https://updates.jenkins-ci.org/latest/#{title}.hpi"
+        end
+
+        include_examples 'execute the right fetch command'
+      end
+
+      context 'with a version' do
+        let(:version) { '1.2.3' }
+        let(:params) { {:plugins_base => plugins_base, :version => version} }
+        let(:expected_url) do
+          "https://updates.jenkins-ci.org/custom_plugins_base/#{title}/#{version}/#{title}.hpi"
+        end
+
+        include_examples 'execute the right fetch command'
+      end
+    end
   end
 
   describe 'source' do


### PR DESCRIPTION
Added plugins_base to be more flexible with custom plugin repositories. We have, for example, an artifactory repository as mirror for both jenkins.war files and plugins. The plugin files are in the path: http://servername/artifactory/jenkins-update/plugins. So no download part here.

Current implementation breaks the Jenkins installation when a symbolic link is used for the plugins or jobs folder. In such case the symbolic link is removed and replaced by an actual folder, effectively removing all jobs from Jenkins \o/.
I added a parameter to follow links in config for setup to enable links for jobs and plugins folder.
