### PR TITLE
Add replace option to plugin configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ parameters will have no effect on the plugin retrieval URL.
 If you need to create a configuration file to go with a plugin you can do this by setting `manage_config => true` *and*
 setting `config_filename => mypluginconfig.xml` *and* setting `config_content => 'string containing xml content of the file'`.
 Note that the filename is relative to `jenkins::localstatedir`, and that the content must be a string,
-although you can embed end of line characters (\n and \r). This is useful if you want to set values in the plugin configuration.
+although you can embed end of line characters if needed. This feature is useful if you want to set values in the plugin configuration.
 
 ```puppet
   jenkins::plugin { 'myplugin':
@@ -221,7 +221,7 @@ the following `require` statement:
 
 ### Plugin Hash
 
-Parameters described in [Installing Jenkins plugins](#installing-jenkins-plugins) can also be used in a plugin hash defined in Hiera.
+Parameters described in [Installing Jenkins plugins](#installing-jenkins-plugins) can also be used in a plugin hash defined in Hiera, for example:
 
 ```yaml
 jenkins::plugin_hash:

--- a/README.md
+++ b/README.md
@@ -141,6 +141,25 @@ hosted in the typical Jenkins' plugin directory structure.
 Note that that when `source` is specified, the `version` and `plugin_url`
 parameters will have no effect on the plugin retrieval URL.
 
+#### Configuration file
+
+If you need to create a configuration file to go with a plugin you can do this by setting `manage_config => true` *and*
+setting `config_filename => mypluginconfig.xml` *and* setting `config_content => 'string containing xml content of the file'`.
+Note that the filename is relative to `jenkins::localstatedir`, and that the content must be a string,
+although you can embed end of line characters (\n and \r). This is useful if you want to set values in the plugin configuration.
+
+```puppet
+  jenkins::plugin { 'myplugin':
+    version         => 2.2.2,
+    manage_config   => true,
+    config_filename => mypluginconfig.xml,
+    config_content  => "<?xml version='1.0' encoding='UTF-8'?><somexml></somexml>",
+  }
+```
+
+By default this will enforce the contents of the config file every time puppet runs. If instead you want to only enforce the
+content if the file does not exist, then also set `config_replace => false`.
+
 #### Plugin dependencies
 Dependencies are not automatically installed. You need to manually determine the plugin dependencies and include those as well. The Jenkins wiki is a good place to do this. For example: The Git plugin page is at https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin.
 
@@ -190,7 +209,7 @@ the following `require` statement:
 
 
 ### Advanced features
-1. Plugin Hash - jenkins::plugins
+1. [Plugin Hash](#plugin-hash) - jenkins::plugin
 2. Config Hash - jennkins::config
 3. Configure Firewall - jenkins (init.pp)
 4. Outbound Jenkins Proxy Config - jenkins (init.pp)
@@ -199,6 +218,21 @@ the following `require` statement:
 6. Jenkins Users
 7. Credentials
 8. Simple security model configuration
+
+### Plugin Hash
+
+Parameters described in [Installing Jenkins plugins](#installing-jenkins-plugins) can also be used in a plugin hash defined in Hiera.
+
+```yaml
+jenkins::plugin_hash:
+  artifactdeployer: {}
+  credentials: {}
+  git:
+    version: 2.4.0
+  git-client:
+    version: 1.19.0
+  javadoc: {}
+```
 
 ### API-based Resources and Settings (Users, Credentials, security)
 

--- a/README.md
+++ b/README.md
@@ -143,32 +143,42 @@ parameters will have no effect on the plugin retrieval URL.
 
 #### Configuration file
 
-If you need to create a configuration file to go with a plugin you can do this by setting `manage_config => true` *and*
-setting `config_filename => mypluginconfig.xml` *and* setting `config_content => 'string containing xml content of the file'`.
-Note that the filename is relative to `jenkins::localstatedir`, and that the content must be a string,
-although you can embed end of line characters if needed. This feature is useful if you want to set values in the plugin configuration.
+If you need to create a configuration file to go with a plugin you can do this
+by setting `manage_config => true` *and* setting
+`config_filename => mypluginconfig.xml` *and* setting
+`config_content => 'string containing xml content of the file'`. Note that the
+filename is relative to `jenkins::localstatedir`, and that the content must be
+a string, although you can embed end of line characters if needed. This
+feature is useful if you want to set values in the plugin configuration.
 
 ```puppet
   jenkins::plugin { 'myplugin':
     version         => 2.2.2,
     manage_config   => true,
     config_filename => mypluginconfig.xml,
-    config_content  => "<?xml version='1.0' encoding='UTF-8'?><somexml></somexml>",
+    config_content  => "<?xml version='1.0' encoding='UTF-8'?><myxml></myxml>",
   }
 ```
 
-By default this will enforce the contents of the config file every time puppet runs. If instead you want to only enforce the
-content if the file does not exist, then also set `config_replace => false`.
+By default this will enforce the contents of the config file every time puppet
+runs. If instead you want to only enforce the content if the file does not
+exist, then also set `config_replace => false`.
 
 #### Plugin dependencies
-Dependencies are not automatically installed. You need to manually determine the plugin dependencies and include those as well. The Jenkins wiki is a good place to do this. For example: The Git plugin page is at https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin.
+Dependencies are not automatically installed. You need to manually determine
+the plugin dependencies and include those as well. The Jenkins wiki is a good
+place to do this. For example: The Git plugin page is at
+https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin.
 
 ### Slaves
-You can automatically add slaves to jenkins, and have them auto register themselves.  Most options are actually optional, as nodes will autodiscover the master, and connect.
+You can automatically add slaves to jenkins, and have them auto register
+themselves.  Most options are actually optional, as nodes will autodiscover
+the master, and connect.
 
 Full documention for the slave code is in jenkins::slave.
 
-It requires the swarm plugin on the master & the class jenkins::slave on the slaves, as below:
+It requires the swarm plugin on the master & the class jenkins::slave on the
+slaves, as below:
 
 ```puppet
     node /jenkins-slave.*/ {
@@ -221,7 +231,9 @@ the following `require` statement:
 
 ### Plugin Hash
 
-Parameters described in [Installing Jenkins plugins](#installing-jenkins-plugins) can also be used in a plugin hash defined in Hiera, for example:
+Parameters described in
+[Installing Jenkins plugins](#installing-jenkins-plugins) can also be used in
+a plugin hash defined in Hiera, for example:
 
 ```yaml
 jenkins::plugin_hash:

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -36,11 +36,13 @@ define jenkins::plugin(
   include ::jenkins
 
   validate_bool($manage_config)
+  validate_bool($config_replace)
   validate_bool($enabled)
   # TODO: validate_str($update_url)
   validate_string($source)
   validate_string($digest_string)
   validate_string($digest_type)
+  
 
   if $plugin_dir {
     warning('jenkins::plugin::plugin_dir is deprecated and has no effect -- see jenkins::localstatedir')
@@ -143,7 +145,7 @@ define jenkins::plugin(
     if $config_filename == undef or $config_content == undef {
       fail 'To deploy config file for plugin, you need to specify both $config_filename and $config_content'
     }
-
+    validate_string($config_filename, $config_content)
     file {"${::jenkins::localstatedir}/${config_filename}":
       ensure  => present,
       content => $config_content,

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -20,6 +20,7 @@ define jenkins::plugin(
   $manage_config   = false,
   $config_filename = undef,
   $config_content  = undef,
+  $config_replace  = true,
   $update_url      = undef,
   $enabled         = true,
   $source          = undef,
@@ -146,6 +147,7 @@ define jenkins::plugin(
     file {"${::jenkins::localstatedir}/${config_filename}":
       ensure  => present,
       content => $config_content,
+      replace => $config_replace,
       owner   => $::jenkins::user,
       group   => $::jenkins::group,
       mode    => '0644',


### PR DESCRIPTION
This adds support for the 'replace' option on plugin configuration files, and adds documentation for configuration files and plugin hash to README.md.
The use case for the replace option is a plugin like gitlab merge request builder (https://github.com/timols/jenkins-gitlab-merge-request-builder-plugin) which needs parameters set in the configuration file, but also stores state in the same configuration file as Jenkins runs. Without the replace option, every puppet run removes that state information.
