### PR TITLE
Feature/fix deprecation warnings

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -11,22 +11,22 @@ class jenkins::repo::debian
 
   if $::jenkins::lts  {
     apt::source { 'jenkins':
-      location    => 'http://pkg.jenkins-ci.org/debian-stable',
-      release     => 'binary/',
-      repos       => '',
-      key         => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-      key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
-      include_src => false,
+      location => 'http://pkg.jenkins-ci.org/debian-stable',
+      release  => 'binary/',
+      repos    => '',
+      key      => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+      source   => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+      include  => { 'src' => false },
     }
   }
   else {
     apt::source { 'jenkins':
-      location    => 'http://pkg.jenkins-ci.org/debian',
-      release     => 'binary/',
-      repos       => '',
-      key         => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-      key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
-      include_src => false,
+      location => 'http://pkg.jenkins-ci.org/debian',
+      release  => 'binary/',
+      repos    => '',
+      key      => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+      source   => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+      include  => { 'src' => false },
     }
   }
 

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -14,8 +14,7 @@ class jenkins::repo::debian
       location => 'http://pkg.jenkins-ci.org/debian-stable',
       release  => 'binary/',
       repos    => '',
-      key      => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-      source   => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+      key      => { 'id' => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6', 'source' => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key'},
       include  => { 'src' => false },
     }
   }
@@ -24,8 +23,7 @@ class jenkins::repo::debian
       location => 'http://pkg.jenkins-ci.org/debian',
       release  => 'binary/',
       repos    => '',
-      key      => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-      source   => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+      key      => { 'id' => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6', 'source' => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key' },
       include  => { 'src' => false },
     }
   }


### PR DESCRIPTION
currently when using this module we get deprecation warnings from the apt module. 
`
 Warning: Scope(Apt::Source[jenkins]): $include_src is deprecated and will be removed in the next major release, please use $include => { 'src' => false } instead
Warning: Scope(Apt::Source[jenkins]): $key_source is deprecated and will be removed in the next major release, please use $key => { 'source' => http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key } instead.
Warning: Scope(Apt::Key[Add key: 150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6 from Apt::Source jenkins]): $key_source is deprecated and will be removed in the next major release. Please use $source instead.
`
this version fixes the warnings.
