### PR TITLE
Return nil for empty jenkins_plugins fact

### DIFF
--- a/lib/puppet/jenkins/facts.rb
+++ b/lib/puppet/jenkins/facts.rb
@@ -33,7 +33,7 @@ module Puppet
           manifest = plugins[plugin]
           buffer << "#{plugin} #{manifest[:plugin_version]}"
         end
-        return buffer.join(', ')
+        return buffer.join(', ') unless buffer.length == 0
       end
     end
   end


### PR DESCRIPTION
This commit updates the jenkins_plugins fact to return nil when there are no jenkins plugins. Without this change the fact generates a empty value and returns an empty string. When no jenkins plugins exist this causes the fact to show up in an unrelated context.
