### PR TITLE
Add folder plugin support for jobs

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -24,6 +24,9 @@
 #   ensure = 'present'
 #     choose 'absent' to ensure the job is removed
 #
+#   folder
+#     name of the folder where the job should be added to (using the Folder plugin)
+#
 #   difftool = '/usr/bin/diff -b-q'
 #     Provide a command to execute to compare Jenkins job files
 #
@@ -34,11 +37,16 @@ define jenkins::job(
   $jobname  = $title,
   $enabled  = 1,
   $ensure   = 'present',
+  $folder   = undef,
   $difftool = '/usr/bin/diff -b -q',
 ){
   include ::jenkins::cli
 
-  validate_string($difftool)
+  validate_string($difftool, $folder)
+
+  if $folder and (!defined(Jenkins::Plugin['cloudbees-folder'])) {
+    fail('cloudbees-folder plugin is required for the \'folder\' parameter.')
+  }
 
   Class['jenkins::cli'] ->
     Jenkins::Job[$title] ->
@@ -65,6 +73,7 @@ define jenkins::job(
       config   => $realconfig,
       jobname  => $jobname,
       enabled  => $enabled,
+      folder   => $folder,
       difftool => $difftool,
     }
   }

--- a/spec/defines/jenkins_job_spec.rb
+++ b/spec/defines/jenkins_job_spec.rb
@@ -159,4 +159,19 @@ eos
     it { should raise_error(Puppet::Error, /Must pass config/) }
   end
 
+  describe 'with folder, regular config and no cloudbees-folder plugin' do
+    quotes = "<xml version='1.0' encoding='UTF-8'></xml>"
+    let(:params) {{ :ensure => 'present', :folder => 'MyFolder', :config => quotes }}
+    it { should raise_error(Puppet::Error, /cloudbees-folder plugin is required/) }
+  end
+
+  describe 'with folder, regular config and cloudbees-folder plugin' do
+    quotes = "<xml version='1.0' encoding='UTF-8'></xml>"
+    let(:params) {{ :ensure => 'present', :folder => 'MyFolder', :config => quotes }}
+    let(:pre_condition) { "jenkins::plugin{'cloudbees-folder':}" }
+    it { should contain_archive__download('cloudbees-folder.hpi') }
+    it { should contain_file('/tmp/MyFolder-myjob-config.xml') }
+  end
+
+
 end


### PR DESCRIPTION
Allow creating jobs inside folders made by the Folder plugin (https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Folders+Plugin)

First, a Folder job needs to exist.

```
# Create Folder job
jenkins::job { 'MyFolder':
  config  => template('jenkins_jobs/folder.xml.erb'),
}
```

Next, we will create a regular job which we want to have added inside the folder we just defined:

```
# Create myproject-default job and add it to MyFolder folder
jenkins::job { "myproject-default":
  folder  => 'MyFolder',
  config  => template('jenkins_jobs/pipelines/tomcat/default.xml.erb'),
  require => Jenkins::Job['MyFolder'],
}
```

Signed-off-by: Christophe Vanlancker christophe.vanlancker@inuits.eu
