### PR TITLE
Bugfix/custom localdir with user: Fixes #462

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,46 +14,5 @@ class jenkins::config {
   )
   create_resources('jenkins::sysconfig', $config_hash)
 
-  $dir_params = {
-    ensure => directory,
-    owner  => $::jenkins::user,
-    group  => $::jenkins::group,
-    mode   => '0755',
-  }
 
-  # ensure_resource is used to try to maintain backwards compatiblity with
-  # manifests that were able to external declare resources due to the
-  # old conditional behavior of jenkins::plugin
-  if $::jenkins::manage_user {
-    ensure_resource('user', $::jenkins::user, {
-      ensure     => present,
-      gid        => $::jenkins::group,
-      home       => $::jenkins::localstatedir,
-      managehome => false,
-      system     => true,
-    })
-  }
-
-  if $::jenkins::manage_group {
-    ensure_resource('group', $::jenkins::group, {
-      ensure => present,
-      system => true,
-    })
-  }
-
-  $plugin_dir_params = $::jenkins::purge_plugins ? {
-    true    => $dir_params + {
-      'purge'   => true,
-      'recurse' => true,
-      'force'   => true,
-      'notify'  => Class['jenkins::service'],
-    },
-    default => $dir_params,
-  }
-
-  if $::jenkins::manage_datadirs {
-    ensure_resource('file', $::jenkins::localstatedir, $dir_params)
-    ensure_resource('file', $::jenkins::plugin_dir, $plugin_dir_params)
-    ensure_resource('file', $::jenkins::job_dir, $dir_params)
-  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -439,6 +439,7 @@ class jenkins(
   }
   include $jenkins_package_class
 
+  include jenkins::user_setup
   include jenkins::config
   include jenkins::plugins
   include jenkins::jobs
@@ -489,6 +490,7 @@ class jenkins(
 
   if $manage_service {
     Anchor['jenkins::begin']
+    -> Class['jenkins::user_setup']
       -> Class[$jenkins_package_class]
         -> Class['jenkins::config']
           -> Class['jenkins::plugins']

--- a/manifests/user_setup.pp
+++ b/manifests/user_setup.pp
@@ -1,0 +1,60 @@
+# This class should be considered private
+#
+# It will optionally create the jenkins user and make sure all
+# directories have proper permissions setup.
+#
+# By having this in a separate class that is managed before
+# installing the package, we can effectivly override the
+# default local dir that is otherwise possibly created by
+# the package.
+#
+class jenkins::user_setup {
+
+  if $caller_module_name != $module_name {
+    fail("Use of private class ${name} by ${caller_module_name}")
+  }
+
+  $dir_params = {
+    ensure => directory,
+    owner  => $::jenkins::user,
+    group  => $::jenkins::group,
+    mode   => '0755',
+  }
+
+  # ensure_resource is used to try to maintain backwards compatiblity with
+  # manifests that were able to external declare resources due to the
+  # old conditional behavior of jenkins::plugin
+  if $::jenkins::manage_user {
+    ensure_resource('user', $::jenkins::user, {
+      ensure     => present,
+      gid        => $::jenkins::group,
+      home       => $::jenkins::localstatedir,
+      managehome => false,
+      system     => true,
+    })
+  }
+
+  if $::jenkins::manage_group {
+    ensure_resource('group', $::jenkins::group, {
+      ensure => present,
+      system => true,
+    })
+  }
+
+  $plugin_dir_params = $::jenkins::purge_plugins ? {
+    true    => $dir_params + {
+      'purge'   => true,
+      'recurse' => true,
+      'force'   => true,
+      'notify'  => Service['jenkins'],
+    },
+    default => $dir_params,
+  }
+
+  if $::jenkins::manage_datadirs {
+    ensure_resource('file', $::jenkins::localstatedir, $dir_params)
+    ensure_resource('file', $::jenkins::plugin_dir, $plugin_dir_params)
+    ensure_resource('file', $::jenkins::job_dir, $dir_params)
+  }
+
+}

--- a/spec/classes/jenkins_user_setup_spec.rb
+++ b/spec/classes/jenkins_user_setup_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe 'jenkins', type: :class do
+  let(:facts) do
+    {
+      osfamily: 'RedHat',
+      operatingsystem: 'RedHat',
+      operatingsystemrelease: '6.7',
+      operatingsystemmajrelease: '6'
+    }
+  end
+
+  context 'user_setup' do
+    context 'default' do
+      it { is_expected.to contain_user('jenkins') }
+      it { is_expected.to contain_group('jenkins') }
+
+      [
+        '/var/lib/jenkins',
+        '/var/lib/jenkins/plugins',
+        '/var/lib/jenkins/jobs'
+      ].each do |datadir|
+        it do
+          is_expected.to contain_file(datadir).with(
+            ensure: 'directory',
+            mode: '0755',
+            group: 'jenkins',
+            owner: 'jenkins'
+          )
+        end
+      end
+    end
+    context 'unmanaged' do
+      let(:params) do
+        {
+          manage_user: false,
+          manage_group: false,
+          manage_datadirs: false
+        }
+      end
+
+      it { is_expected.not_to contain_user('jenkins') }
+      it { is_expected.not_to contain_group('jenkins') }
+      it { is_expected.not_to contain_file('/var/lib/jenkins') }
+      it { is_expected.not_to contain_file('/var/lib/jenkins/jobs') }
+      it { is_expected.not_to contain_file('/var/lib/jenkins/plugins') }
+    end
+
+    context 'custom home' do
+      let(:params) do
+        {
+          localstatedir: '/custom/jenkins'
+        }
+      end
+
+      it { is_expected.to contain_user('jenkins').with_home('/custom/jenkins') }
+      it { is_expected.to contain_file('/custom/jenkins') }
+      it { is_expected.to contain_file('/custom/jenkins/plugins') }
+      it { is_expected.to contain_file('/custom/jenkins/jobs') }
+    end
+  end
+end


### PR DESCRIPTION
By splitting out the user creation, we can have a custom
localdir before the package (maybe) tries to create it or adjust it.