### PR TITLE
enables the use of a template for the plugin configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ README.pdf
 .ruby-*
 *.sw*
 spec/fixtures
+!spec/fixtures/modules/site_jenkins
 Gemfile.lock
 .vagrant*
 .bundle

--- a/spec/fixtures/modules/site_jenkins/templates/fake_config.epp
+++ b/spec/fixtures/modules/site_jenkins/templates/fake_config.epp
@@ -1,0 +1,6 @@
+<%- | String $param1 = 'default1',
+      String $param2 = 'default2',
+| -%>
+This is a fake template for rspec testing
+parameter1 = <%= $param1 %>
+parameter2 = <%= $param2 %>

--- a/spec/fixtures/modules/site_jenkins/templates/fake_config.erb
+++ b/spec/fixtures/modules/site_jenkins/templates/fake_config.erb
@@ -1,0 +1,2 @@
+This is a fake template for testing purposes.
+Configured for plugin <%= @title %> version <%= @version %>


### PR DESCRIPTION
Installing plugins using hiera and the jenkins::plugins class, it is impossible to generate the config_content using a template.  With this addition, it becomes a piece of cake. 
