### PR TITLE
Quote job name in commands involving it

### DIFF
--- a/manifests/job/present.pp
+++ b/manifests/job/present.pp
@@ -82,11 +82,11 @@ define jenkins::job::present(
   }
 
   # Use Jenkins CLI to update the job if it already exists
-  $update_job = "${jenkins_cli} update-job ${jobname}"
+  $update_job = "${jenkins_cli} update-job '${jobname}'"
   exec { "jenkins update-job ${jobname}":
     command => "${cat_config} | ${update_job}",
-    onlyif  => "test -e ${config_path}",
-    unless  => "${difftool} ${config_path} ${tmp_config_path}",
+    onlyif  => "test -e '${config_path}'",
+    unless  => "${difftool} '${config_path}' '${tmp_config_path}'",
     require => File[$tmp_config_path],
     notify  => Exec['reload-jenkins'],
   }

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -9,14 +9,22 @@ class jenkins::repo::debian
   include stdlib
   include apt
 
+  $keydata = {
+      'id'     => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+      'source' => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+  }
+
+  $includedata = {
+      'src' =>  false,
+  }
+
   if $::jenkins::lts  {
     apt::source { 'jenkins':
       location    => 'http://pkg.jenkins-ci.org/debian-stable',
       release     => 'binary/',
       repos       => '',
-      key         => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-      key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
-      include_src => false,
+      key         => $keydata,
+      include     => $includedata,
     }
   }
   else {
@@ -24,9 +32,8 @@ class jenkins::repo::debian
       location    => 'http://pkg.jenkins-ci.org/debian',
       release     => 'binary/',
       repos       => '',
-      key         => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-      key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
-      include_src => false,
+      key         => $keydata,
+      include     => $includedata,
     }
   }
 

--- a/spec/defines/jenkins_job_spec.rb
+++ b/spec/defines/jenkins_job_spec.rb
@@ -207,4 +207,16 @@ eos
     end
   end
 
+  describe 'with an existing job name with spaces' do
+    let(:title) { 'my job' }
+    let(:params) {{ :config => '' }}
+    it {
+      should contain_exec("jenkins update-job #{title}")
+        .with_command("cat \"/tmp/my job-config.xml\" | " \
+                      "java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 update-job 'my job'")
+        .with_onlyif("test -e '/var/lib/jenkins/jobs/my job/config.xml'")
+        .with_unless("/usr/bin/diff -b -q '/var/lib/jenkins/jobs/my job/config.xml' '/tmp/my job-config.xml'")
+    }
+  end
+
 end


### PR DESCRIPTION
Updating a job currently fails if the job name includes a space.
