### PR TITLE
Allow specification of additional JAVA_ARGS

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,8 +8,22 @@ class jenkins::config {
 
   ensure_resource('jenkins::plugin', $::jenkins::default_plugins)
 
+  $java_args = concat(
+    $::jenkins::params::_default_java_args,
+    $::jenkins::java_args
+  )
+
+  $config_defaults = {
+    "${::jenkins::params::config_prefix}JAVA_ARGS" => {
+      value => join($java_args, ' ')
+    },
+    "${::jenkins::params::config_prefix}AJP_PORT" => {
+      value => '-1'
+    }
+  }
+
   $config_hash = merge(
-    $::jenkins::params::config_hash_defaults,
+    $config_defaults,
     $::jenkins::config_hash
   )
   create_resources('jenkins::sysconfig', $config_hash)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -307,6 +307,7 @@ class jenkins(
   $group              = $::jenkins::params::group,
   $default_plugins    = $::jenkins::params::default_plugins,
   $purge_plugins      = $::jenkins::params::purge_plugins,
+  $java_args          = [],
 ) inherits jenkins::params {
 
   validate_string($version)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,7 +25,7 @@ class jenkins::params {
   $user         = 'jenkins'
   $manage_group = true
   $group        = 'jenkins'
-  $_java_args   = '-Djava.awt.headless=true -Djenkins.install.runSetupWizard=false'
+  $_default_java_args = ['-Djava.awt.headless=true','-Djenkins.install.runSetupWizard=false']
   $default_plugins = [
     'credentials', # required by puppet_helper.groovy
   ]
@@ -37,19 +37,13 @@ class jenkins::params {
       $package_provider = 'dpkg'
       $service_provider = undef
       $sysconfdir       = '/etc/default'
-      $config_hash_defaults = {
-        'JAVA_ARGS' => { value => $_java_args },
-        'AJP_PORT'  => { value => '-1' },
-      }
+      $config_prefix = ''
     }
     'RedHat': {
       $libdir           = '/usr/lib/jenkins'
       $package_provider = 'rpm'
       $sysconfdir           = '/etc/sysconfig'
-      $config_hash_defaults = {
-        'JENKINS_JAVA_OPTIONS' => { value => $_java_args },
-        'JENKINS_AJP_PORT'     => { value => '-1' },
-      }
+      $config_prefix = 'JENKINS_'
 
       # explicitly use systemd if it is available
       # XXX only enable explicit systemd support on RedHat at this time due to
@@ -70,10 +64,7 @@ class jenkins::params {
       $package_provider     = undef
       $service_provider     = undef
       $sysconfdir           = '/etc/sysconfig'
-      $config_hash_defaults = {
-        'JENKINS_JAVA_OPTIONS' => { value => $_java_args },
-        'JENKINS_AJP_PORT'     => { value => '-1' },
-      }
+      $config_prefix = 'JENKINS_'
     }
   }
 }


### PR DESCRIPTION
I just upgraded my jenkins module (from 1.4.0), and in upgrading things, ran into the fact that the Jenkins module now manages the INI settings in /etc/default/jenkins (in Debian). I had been setting a few options of my own with `inifile`, which Jenkins' management overwrote.

In the end I decided to solve it by implementing an option to specify additional `JAVA_ARGS` to the module. In doing so, I moved a little bit more of the logic into `config.pp`, in order to allow adding custom JAVA_ARGS.

I wasn't able to get a test environment up, so this PR is partially to get acceptance tests run as well.