### PR TITLE
Adding PAM as a user realm

### DIFF
--- a/manifests/security.pp
+++ b/manifests/security.pp
@@ -17,8 +17,10 @@
 # Jenkins security configuration
 #
 class jenkins::security (
-  String $security_model,
+  String $security_model = undef,
+  String $user_realm     = 'internal',
 ){
+
   include ::jenkins::cli_helper
 
   Class['jenkins::cli_helper']
@@ -26,11 +28,13 @@ class jenkins::security (
       -> Anchor['jenkins::end']
 
   # XXX not idempotent
-  jenkins::cli::exec { "jenkins-security-${security_model}":
+  jenkins::cli::exec { "jenkins-security-${security_model}-${user_realm}":
     command => [
       'set_security',
       $security_model,
+      $user_realm,
     ],
-    unless  => "\$HELPER_CMD get_authorization_strategyname | grep -q -e '^${security_model}\$'",
+    unless  => "\$HELPER_CMD get_authorization_strategyname | grep -q -e '^${security_model}\$' \
+                && \$HELPER_CMD get_authorization_realmname | grep -q -e '^${user_realm}\$' ",
   }
 }


### PR DESCRIPTION
Like #606 for LDAP, this PR adds the pam authentication for Jenkins.
The configuration of pam Auth works fine for me. 
I still have trouble with Jenkins only supporting one security realm provider (https://issues.jenkins-ci.org/browse/JENKINS-15063).
Therefore as soon as I configure PAM auth with puppet, the puppet Jenkins configuration user (who is in Jenkins own user database) stops working and there seems to be no way, to automate the deployment of Jenkins with pam.
The only workaround I can think of would be a user in the Linux system with the exact same username and password as the Jenkins admin+initialAdminPassword.
But I'm not sure how to implement this right now.
Any ideas or suggestions on that?
