### PR TITLE
Fixing incorrect port used by CLI when non default specified.

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -51,7 +51,7 @@ class jenkins::cli {
     require => Exec['jenkins-cli'],
   }
 
-  $port = jenkins_port()
+  $port = $::jenkins::port
   $prefix = jenkins_prefix()
 
   # The jenkins cli command with required parameter(s)

--- a/manifests/cli_helper.pp
+++ b/manifests/cli_helper.pp
@@ -21,7 +21,7 @@ class jenkins::cli_helper (
 
   $libdir = $::jenkins::libdir
   $cli_jar = $::jenkins::cli::jar
-  $port = jenkins_port()
+  $port = $::jenkins::port
   $prefix = jenkins_prefix()
   $helper_groovy = "${libdir}/puppet_helper.groovy"
 


### PR DESCRIPTION
Using `jenkins::port` in Hiera did not change the port the CLI uses.