### PR TITLE
Make all archive options accessible for plugin type

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -26,6 +26,7 @@ define jenkins::plugin(
   Boolean $enabled                  = true,
   String $digest_type               = 'sha1',
   Boolean $pin                      = false,
+  Hash $archive_options             = {},
   # no worky
   Any $timeout                      = undef,
   # deprecated
@@ -173,11 +174,11 @@ define jenkins::plugin(
       checksum_verify => $checksum_verify,
       checksum        => $checksum,
       checksum_type   => $checksum_type,
-      proxy_server    => $::jenkins::proxy::url,
       cleanup         => false,
       extract         => false,
       require         => File[$::jenkins::plugin_dir],
       notify          => Service['jenkins'],
+      *               => $archive_options,
     }
     $archive_require = Archive[$plugin]
   } else {

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -136,6 +136,11 @@ describe 'jenkins::plugin' do
           proxy_host => "proxy.company.com",
           proxy_port => 8080,
         }
+        Jenkins::Plugin {
+          archive_options => {
+            proxy_server => 'http://proxy.company.com:8080',
+          }
+        }
       EOS
     end
 


### PR DESCRIPTION
At our organization, we are downloading plugins from our own caching
mirror, but we can't access our internal mirror through our proxy
server, and we do need to authenticate to this server.

With this change, archive (and in turn, curl) will pick up the proxy
configuration from environment variables or ~/.curlrc, including the
no_proxy setting we need. When users desire to override those, they can
still specify proxy_server directly.

For authenticating with the download server, we can pass username and
password to archive.

In our private wrapper module, we set default for the jenkins::plugin
type:
```
Jenkins::Plugin {
  archive_options => |
    username => $artifactory_username,
    password => $artifactory_password,
}
```

This works because we define the defaults and the actual resources
inside the same class. Setting defaults for types is guaranteed by
Puppet only for resources declared in the same class, so we cannot
set defaults on the archive type.

If full backwards compatibility is desired, the parameter declaration
could be changed to:
```
  Hash $archive_options = { 'proxy_server' => $::jenkins::proxy::url },
```