### PR TITLE
Run apt_update when defining debian repos

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -26,6 +26,7 @@ class jenkins::repo::debian
         'source' => "${pkg_host}/debian/jenkins-ci.org.key",
       },
       require  => Package['apt-transport-https'],
+      notify   => Exec['apt_update'],
     }
   }
   else {
@@ -41,6 +42,7 @@ class jenkins::repo::debian
         'source' => "${pkg_host}/debian/jenkins-ci.org.key",
       },
       require  => Package['apt-transport-https'],
+      notify   => Exec['apt_update'],
     }
   }
 

--- a/spec/classes/jenkins_repo_debian_spec.rb
+++ b/spec/classes/jenkins_repo_debian_spec.rb
@@ -18,6 +18,7 @@ describe 'jenkins', :type => :module do
   context 'repo::debian' do
     shared_examples 'an apt catalog' do
       it { should contain_class('apt') }
+      it { should contain_apt__source('jenkins').that_notifies('Exec[apt_update]') }
     end
 
     describe 'default' do


### PR DESCRIPTION
As per the puppetlabs/apt documentation, there should be a `notify => Exec['apt_update']` when defining repos using apt::sources, otherwise there is no guarantee that the packages in the new repo will be available the next time Apt tries to install a package.