### PR TITLE
drop legacy puppet version from testmatrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ rvm:
 script:
   - "bundle exec rake SPEC_OPTS='--format documentation --order random'"
 env:
-  - PUPPET_VERSION="~> 4.9.0"
   - PUPPET_VERSION="~> 4.10.0"
 matrix:
   include:


### PR DESCRIPTION
There is no need to test against two Puppet 4.X versions.