### PR TITLE
Add support for GoogleRobotPrivateKeyCredentials

### DIFF
--- a/NATIVE_TYPES_AND_PROVIDERS.md
+++ b/NATIVE_TYPES_AND_PROVIDERS.md
@@ -384,6 +384,33 @@ jenkins_credentials { '7e86e9fb-a8af-480f-b596-7191dc02bf38':
 }
 ```
 
+### `GoogleRobotPrivateKeyCredentials`
+
+Using this credential type requires that the jenkins `google-oauth-plugin` plugin
+has been installed.
+
+```
+jenkins_credentials { '587690b0-f793-44e6-bc46-889cce58fb71':
+  ensure   => 'present',
+  impl     => 'GoogleRobotPrivateKeyCredentials',
+  json_key => @END
+  {
+    "client_email": "random@developer.gserviceaccount.com",
+    "private_key": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+  }
+  | END,
+}
+```
+or
+```
+jenkins_credentials { '2f867d0d-e0c7-48a6-a355-1d4fd2ac6c22':
+  ensure        => 'present',
+  impl          => 'GoogleRobotPrivateKeyCredentials',
+  email_address => 'random@developer.gserviceaccount.com',
+  p12_key       => 'LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCg==',
+}
+```
+
 ### `jenkins_job`
 
 ```

--- a/files/puppet_helper.groovy
+++ b/files/puppet_helper.groovy
@@ -653,12 +653,12 @@ class Actions {
       case 'GoogleRobotPrivateKeyCredentials':
         util.requirePlugin('google-oauth-plugin')
 
-        def getFileItemFromString = { id, keyString, classLoader ->
+        def getFileItemFromString = { id, keyByteArray, classLoader ->
           def fileItemFactory = classLoader.loadClass('org.apache.commons.fileupload.disk.DiskFileItemFactory').newInstance()
-          fileItemFactory.setSizeThreshold(keyString.length())
+          fileItemFactory.setSizeThreshold(keyByteArray.length())
           def fileItem = fileItemFactory.createItem('tempfile', 'plain/text', false, id)
           def outputStream = fileItem.getOutputStream()
-          outputStream.write(keyString.getBytes(), 0 , keyString.length())
+          outputStream.write(keyByteArray, 0 , keyByteArray.length())
           outputStream.flush()
           outputStream.close()
 
@@ -668,13 +668,13 @@ class Actions {
         def serviceAccountConfig = null
         if (conf['json_key'] != null) {
           serviceAccountConfig = this.class.classLoader.loadClass('com.google.jenkins.plugins.credentials.oauth.JsonServiceAccountConfig').newInstance(
-            getFileItemFromString(conf['id'], conf['json_key'], this.class.classLoader),
+            getFileItemFromString(conf['id'], conf['json_key'].getBytes(), this.class.classLoader),
             null
           )
         } else if (conf['email_address'] != null && conf['p12_key'] != null) {
           serviceAccountConfig = this.class.classLoader.loadClass('com.google.jenkins.plugins.credentials.oauth.P12ServiceAccountConfig').newInstance(
             conf['email_address'],
-            getFileItemFromString(conf['id'], conf['p12_key'], this.class.classLoader),
+            getFileItemFromString(conf['id'], conf['p12_key'].decodeBase64(), this.class.classLoader),
             null
           )
         } else {

--- a/files/puppet_helper.groovy
+++ b/files/puppet_helper.groovy
@@ -546,6 +546,10 @@ class Actions {
               throw new UnsupportedCredentialsClass("unsupported " + keyStoreSource)
           }
           break
+        case 'com.google.jenkins.plugins.credentials.oauth.GoogleRobotPrivateKeyCredentials':
+          info['account_id'] = cred.getServiceAccountConfig().getAccountId()
+          info['private_key'] = new String(cred.getServiceAccountConfig().getPrivateKey().getEncoded())
+          break
         default:
           throw new UnsupportedCredentialsClass("unsupported " + cred)
       }

--- a/files/puppet_helper.groovy
+++ b/files/puppet_helper.groovy
@@ -655,10 +655,10 @@ class Actions {
 
         def getFileItemFromString = { id, keyByteArray, classLoader ->
           def fileItemFactory = classLoader.loadClass('org.apache.commons.fileupload.disk.DiskFileItemFactory').newInstance()
-          fileItemFactory.setSizeThreshold(keyByteArray.length())
+          fileItemFactory.setSizeThreshold(keyByteArray.length)
           def fileItem = fileItemFactory.createItem('tempfile', 'plain/text', false, id)
           def outputStream = fileItem.getOutputStream()
-          outputStream.write(keyByteArray, 0 , keyByteArray.length())
+          outputStream.write(keyByteArray, 0 , keyByteArray.length)
           outputStream.flush()
           outputStream.close()
 

--- a/files/puppet_helper.groovy
+++ b/files/puppet_helper.groovy
@@ -683,7 +683,8 @@ class Actions {
 
         cred = this.class.classLoader.loadClass('com.google.jenkins.plugins.credentials.oauth.GoogleRobotPrivateKeyCredentials').newInstance(
           conf['id'],
-          serviceAccountConfig
+          serviceAccountConfig,
+          null
         )
         break
       default:

--- a/lib/puppet/provider/jenkins_credentials/cli.rb
+++ b/lib/puppet/provider/jenkins_credentials/cli.rb
@@ -64,6 +64,9 @@ Puppet::Type.type(:jenkins_credentials).provide(:cli, parent: Puppet::X::Jenkins
       [:description, :api_token].each { |k| copy_key(params, info, k) }
     when 'GoogleRobotPrivateKeyCredentials'
       [:json_key, :email_address, :p12_key].each { |k| copy_key(params, info, k) }
+      # Since the plugin does not allow to configure the description of the credentials,
+      # we will just hardcode it to the default value.
+      params[:description] = 'Managed by Puppet'
     when 'ConduitCredentialsImpl'
       [:description, :token, :url].each { |k| copy_key(params, info, k) }
 

--- a/lib/puppet/provider/jenkins_credentials/cli.rb
+++ b/lib/puppet/provider/jenkins_credentials/cli.rb
@@ -62,6 +62,8 @@ Puppet::Type.type(:jenkins_credentials).provide(:cli, parent: Puppet::X::Jenkins
       [:description, :secret_key, :access_key].each { |k| copy_key(params, info, k) }
     when 'GitLabApiTokenImpl'
       [:description, :api_token].each { |k| copy_key(params, info, k) }
+    when 'GoogleRobotPrivateKeyCredentials'
+      [:json_key, :email_address, :p12_key].each { |k| copy_key(params, info, k) }
     when 'ConduitCredentialsImpl'
       [:description, :token, :url].each { |k| copy_key(params, info, k) }
 

--- a/lib/puppet/type/jenkins_credentials.rb
+++ b/lib/puppet/type/jenkins_credentials.rb
@@ -103,17 +103,14 @@ Puppet::X::Jenkins::Type::Cli.newtype(:jenkins_credentials) do
 
   newproperty(:json_key) do
     desc 'JSON key string - GoogleRobotPrivateKeyCredentials'
-    defaultto :undef
   end
 
   newproperty(:email_address) do
     desc 'Email address used with a P12 key - GoogleRobotPrivateKeyCredentials'
-    defaultto :undef
   end
 
   newproperty(:p12_key) do
     desc 'P12 key string - GoogleRobotPrivateKeyCredentials'
-    defaultto :undef
   end
 
   # require all authentication & authorization related types

--- a/lib/puppet/type/jenkins_credentials.rb
+++ b/lib/puppet/type/jenkins_credentials.rb
@@ -110,7 +110,7 @@ Puppet::X::Jenkins::Type::Cli.newtype(:jenkins_credentials) do
   end
 
   newproperty(:p12_key) do
-    desc 'P12 key string - GoogleRobotPrivateKeyCredentials'
+    desc 'P12 key string in Base64 format - GoogleRobotPrivateKeyCredentials'
   end
 
   # require all authentication & authorization related types

--- a/lib/puppet/type/jenkins_credentials.rb
+++ b/lib/puppet/type/jenkins_credentials.rb
@@ -102,7 +102,7 @@ Puppet::X::Jenkins::Type::Cli.newtype(:jenkins_credentials) do
   end
 
   newproperty(:json_key) do
-    desc 'JSON key string - GoogleRobotPrivateKeyCredentials'
+    desc 'Prettified JSON key string - GoogleRobotPrivateKeyCredentials'
   end
 
   newproperty(:email_address) do
@@ -110,7 +110,7 @@ Puppet::X::Jenkins::Type::Cli.newtype(:jenkins_credentials) do
   end
 
   newproperty(:p12_key) do
-    desc 'P12 key string in Base64 format - GoogleRobotPrivateKeyCredentials'
+    desc 'P12 key string in Base64 format without line wrapping - GoogleRobotPrivateKeyCredentials'
   end
 
   # require all authentication & authorization related types

--- a/lib/puppet/type/jenkins_credentials.rb
+++ b/lib/puppet/type/jenkins_credentials.rb
@@ -36,7 +36,8 @@ Puppet::X::Jenkins::Type::Cli.newtype(:jenkins_credentials) do
               :StringCredentialsImpl,
               :FileCredentialsImpl,
               :AWSCredentialsImpl,
-              :GitLabApiTokenImpl)
+              :GitLabApiTokenImpl,
+              :GoogleRobotPrivateKeyCredentials)
   end
 
   newproperty(:description) do
@@ -98,6 +99,21 @@ Puppet::X::Jenkins::Type::Cli.newtype(:jenkins_credentials) do
 
   newproperty(:url) do
     desc 'URL of phabriactor installation - ConduitCredentialsImpl'
+  end
+
+  newproperty(:json_key) do
+    desc 'JSON key string - GoogleRobotPrivateKeyCredentials'
+    defaultto :undef
+  end
+
+  newproperty(:email_address) do
+    desc 'Email address used with a P12 key - GoogleRobotPrivateKeyCredentials'
+    defaultto :undef
+  end
+
+  newproperty(:p12_key) do
+    desc 'P12 key string - GoogleRobotPrivateKeyCredentials'
+    defaultto :undef
   end
 
   # require all authentication & authorization related types

--- a/spec/acceptance/xtypes/jenkins_credentials_spec.rb
+++ b/spec/acceptance/xtypes/jenkins_credentials_spec.rb
@@ -223,6 +223,76 @@ describe 'jenkins_credentials' do
           }
         end
       end
+
+      context 'GoogleRobotPrivateKeyCredentials with json_key' do
+        it 'works with no errors' do
+          pending('jenkins plugin tests are not consistently failing or succeeding: https://github.com/voxpupuli/puppet-jenkins/issues/839')
+          pp = base_manifest + <<-EOS
+            jenkins::plugin { [
+              'google-oauth-plugin',
+              'credentials',
+              'structs',
+              'oauth-credentials',
+            ]: }
+
+            jenkins_credentials { '587690b0-f793-44e6-bc46-889cce58fb71':
+              ensure   => 'present',
+              impl     => 'GoogleRobotPrivateKeyCredentials',
+              json_key => @END
+              {
+                "client_email": "random@developer.gserviceaccount.com",
+                "private_key": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+              }
+              | END,
+            }
+          EOS
+
+          apply2(pp)
+        end
+
+        describe file('/var/lib/jenkins/credentials.xml') do
+          # XXX need to properly compare the XML doc
+          # trying to match anything other than the id this way might match other
+          # credentails
+          it {
+            pending('jenkins plugin tests are not consistently failing or succeeding: https://github.com/voxpupuli/puppet-jenkins/issues/839')
+            is_expected.to contain '<projectId>587690b0-f793-44e6-bc46-889cce58fb71</projectId>'
+          }
+        end
+      end
+
+      context 'GoogleRobotPrivateKeyCredentials with email_address and p12_key' do
+        it 'works with no errors' do
+          pending('jenkins plugin tests are not consistently failing or succeeding: https://github.com/voxpupuli/puppet-jenkins/issues/839')
+          pp = base_manifest + <<-EOS
+            jenkins::plugin { [
+              'google-oauth-plugin',
+              'credentials',
+              'structs',
+              'oauth-credentials',
+            ]: }
+
+            jenkins_credentials { '2f867d0d-e0c7-48a6-a355-1d4fd2ac6c22':
+              ensure        => 'present',
+              impl          => 'GoogleRobotPrivateKeyCredentials',
+              email_address => 'random@developer.gserviceaccount.com',
+              p12_key       => 'LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCg==',
+            }
+          EOS
+
+          apply2(pp)
+        end
+
+        describe file('/var/lib/jenkins/credentials.xml') do
+          # XXX need to properly compare the XML doc
+          # trying to match anything other than the id this way might match other
+          # credentails
+          it {
+            pending('jenkins plugin tests are not consistently failing or succeeding: https://github.com/voxpupuli/puppet-jenkins/issues/839')
+            is_expected.to contain '<projectId>2f867d0d-e0c7-48a6-a355-1d4fd2ac6c22</projectId>'
+          }
+        end
+      end
     end # 'present' do
 
     context 'absent' do

--- a/spec/unit/puppet/provider/jenkins_credentials/cli_spec.rb
+++ b/spec/unit/puppet/provider/jenkins_credentials/cli_spec.rb
@@ -59,6 +59,21 @@ describe Puppet::Type.type(:jenkins_credentials).provider(:cli) do
             "impl": "GitLabApiTokenImpl",
             "description": "GitLab API token",
             "api_token": "tokens for days"
+        },
+        {
+          "id": "587690b0-f793-44e6-bc46-889cce58fb71",
+          "domain": null,
+          "scope": null,
+          "impl": "GoogleRobotPrivateKeyCredentials",
+          "json_key": "{\"client_email\":\"random@developer.gserviceaccount.com\",\"private_key\":\"-----BEGIN PRIVATE KEY-----\\\\n...\\\\n-----END PRIVATE KEY-----\\\\n\"}"
+        },
+        {
+          "id": "2f867d0d-e0c7-48a6-a355-1d4fd2ac6c22",
+          "domain": null,
+          "scope": null,
+          "impl": "GoogleRobotPrivateKeyCredentials",
+          "email_address": "random@developer.gserviceaccount.com",
+          "p12_key": "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCg==",
         }
     ]
     EOS
@@ -92,6 +107,9 @@ describe Puppet::Type.type(:jenkins_credentials).provider(:cli) do
         key_store_impl
         secret_key
         access_key
+        email_address
+        p12_key
+        json_key
       ].each do |k|
         expect(provider.public_send(k.to_sym)).to eq :absent
       end
@@ -125,6 +143,9 @@ describe Puppet::Type.type(:jenkins_credentials).provider(:cli) do
         key_store_impl
         secret_key
         access_key
+        email_address
+        p12_key
+        json_key
       ].each do |k|
         expect(provider.public_send(k.to_sym)).to eq :absent
       end
@@ -158,6 +179,9 @@ describe Puppet::Type.type(:jenkins_credentials).provider(:cli) do
         key_store_impl
         secret_key
         access_key
+        email_address
+        p12_key
+        json_key
       ].each do |k|
         expect(provider.public_send(k.to_sym)).to eq :absent
       end
@@ -191,6 +215,9 @@ describe Puppet::Type.type(:jenkins_credentials).provider(:cli) do
         key_store_impl
         secret_key
         access_key
+        email_address
+        p12_key
+        json_key
       ].each do |k|
         expect(provider.public_send(k.to_sym)).to eq :absent
       end
@@ -223,6 +250,9 @@ describe Puppet::Type.type(:jenkins_credentials).provider(:cli) do
         key_store_impl
         content
         file_name
+        email_address
+        p12_key
+        json_key
       ].each do |k|
         expect(provider.public_send(k.to_sym)).to eq :absent
       end
@@ -256,6 +286,74 @@ describe Puppet::Type.type(:jenkins_credentials).provider(:cli) do
         file_name
         secret_key
         access_key
+        email_address
+        p12_key
+        json_key
+      ].each do |k|
+        expect(provider.public_send(k.to_sym)).to eq :absent
+      end
+    end
+  end
+
+  shared_examples 'a provider from example hash 7' do
+    it do
+      cred = credentials[5]
+
+      expect(provider.name).to eq cred['id']
+      expect(provider.ensure).to eq :present
+      %w[
+        domain
+        scope
+        impl
+        json_key
+      ].each do |k|
+        expect(provider.public_send(k.to_sym)).to eq cred[k].nil? ? :undef : cred[k]
+      end
+
+      %w[
+        username
+        password
+        private_key
+        passphrase
+        source
+        key_store_impl
+        content
+        file_name
+        secret_key
+        access_key
+      ].each do |k|
+        expect(provider.public_send(k.to_sym)).to eq :absent
+      end
+    end
+  end
+
+  shared_examples 'a provider from example hash 8' do
+    it do
+      cred = credentials[5]
+
+      expect(provider.name).to eq cred['id']
+      expect(provider.ensure).to eq :present
+      %w[
+        domain
+        scope
+        impl
+        email_address
+        p12_key
+      ].each do |k|
+        expect(provider.public_send(k.to_sym)).to eq cred[k].nil? ? :undef : cred[k]
+      end
+
+      %w[
+        username
+        password
+        private_key
+        passphrase
+        source
+        key_store_impl
+        content
+        file_name
+        secret_key
+        access_key
       ].each do |k|
         expect(provider.public_send(k.to_sym)).to eq :absent
       end
@@ -272,7 +370,7 @@ describe Puppet::Type.type(:jenkins_credentials).provider(:cli) do
       end
 
       it 'returns the correct number of instances' do
-        expect(described_class.instances.size).to eq 6
+        expect(described_class.instances.size).to eq 8
       end
 
       context 'first instance returned' do

--- a/spec/unit/puppet/provider/jenkins_credentials/cli_spec.rb
+++ b/spec/unit/puppet/provider/jenkins_credentials/cli_spec.rb
@@ -65,7 +65,7 @@ describe Puppet::Type.type(:jenkins_credentials).provider(:cli) do
           "domain": null,
           "scope": null,
           "impl": "GoogleRobotPrivateKeyCredentials",
-          "json_key": "{\"client_email\":\"random@developer.gserviceaccount.com\",\"private_key\":\"-----BEGIN PRIVATE KEY-----\\\\n...\\\\n-----END PRIVATE KEY-----\\\\n\"}"
+          "json_key": "{\\\"client_email\\\":\\\"random@developer.gserviceaccount.com\\\",\\\"private_key\\\":\\\"-----BEGIN PRIVATE KEY-----\\\\n...\\\\n-----END PRIVATE KEY-----\\\\n\\\"}"
         },
         {
           "id": "2f867d0d-e0c7-48a6-a355-1d4fd2ac6c22",

--- a/spec/unit/puppet/provider/jenkins_credentials/cli_spec.rb
+++ b/spec/unit/puppet/provider/jenkins_credentials/cli_spec.rb
@@ -73,7 +73,7 @@ describe Puppet::Type.type(:jenkins_credentials).provider(:cli) do
           "scope": null,
           "impl": "GoogleRobotPrivateKeyCredentials",
           "email_address": "random@developer.gserviceaccount.com",
-          "p12_key": "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCg==",
+          "p12_key": "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCg=="
         }
     ]
     EOS

--- a/spec/unit/puppet/type/jenkins_credentials_spec.rb
+++ b/spec/unit/puppet/type/jenkins_credentials_spec.rb
@@ -33,7 +33,7 @@ describe Puppet::Type.type(:jenkins_credentials) do
                         :FileCredentialsImpl,
                         :AWSCredentialsImpl,
                         :GitLabApiTokenImpl,
-                        :GoogleRobotPrivateKeyCredentials,
+                        :GoogleRobotPrivateKeyCredentials
                       ]
     end
 
@@ -54,7 +54,7 @@ describe Puppet::Type.type(:jenkins_credentials) do
       :api_token,
       :email_address,
       :p12_key,
-      :json_key,
+      :json_key
     ].each do |property|
       describe property.to_s do
         context 'attrtype' do

--- a/spec/unit/puppet/type/jenkins_credentials_spec.rb
+++ b/spec/unit/puppet/type/jenkins_credentials_spec.rb
@@ -32,7 +32,8 @@ describe Puppet::Type.type(:jenkins_credentials) do
                         :StringCredentialsImpl,
                         :FileCredentialsImpl,
                         :AWSCredentialsImpl,
-                        :GitLabApiTokenImpl
+                        :GitLabApiTokenImpl,
+                        :GoogleRobotPrivateKeyCredentials,
                       ]
     end
 
@@ -50,7 +51,10 @@ describe Puppet::Type.type(:jenkins_credentials) do
       :key_store_impl,
       :secret_key,
       :access_key,
-      :api_token
+      :api_token,
+      :email_address,
+      :p12_key,
+      :json_key,
     ].each do |property|
       describe property.to_s do
         context 'attrtype' do


### PR DESCRIPTION
Extends the `credentials_list_json` method in the `puppet_helpers.groovy` script to support `com.google.jenkins.plugins.credentials.oauth.GoogleRobotPrivateKeyCredentials`.