### PR TITLE
fix docker sets indent

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,7 +1,7 @@
 ---
 .travis.yml:
-    docker_sets:
+  secure: "cQdjbcwx+q/ArSkOtnxMYmlsWnJmyNEz7IUmpSx3F/z1ntX75/J3mJYFgYuvrOw2IbmmuwgVPofBpJjJajkhGOpaywOjKA6PgxKzSEu6e/q5CXJwMLnsDhHqY6X9bdGF5TU/DUkNzxBQlI7uDyk3yBVAACzLGMTCFksoztdlIbI="
+  docker_sets:
     - set: docker/ubuntu-14.04
     - set: docker/ubuntu-16.04
     - set: docker/centos-7
-  secure: "cQdjbcwx+q/ArSkOtnxMYmlsWnJmyNEz7IUmpSx3F/z1ntX75/J3mJYFgYuvrOw2IbmmuwgVPofBpJjJajkhGOpaywOjKA6PgxKzSEu6e/q5CXJwMLnsDhHqY6X9bdGF5TU/DUkNzxBQlI7uDyk3yBVAACzLGMTCFksoztdlIbI="


### PR DESCRIPTION
I think `docker_sets` should be indented 2 spaces instead of 4 here