### PR TITLE
Refactor repository handling

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,7 +1,10 @@
 #
 # jenkins::repo handles pulling in the platform specific repo classes
 #
-class jenkins::repo {
+class jenkins::repo(
+  Stdlib::Httpurl $base_url = 'https://pkg.jenkins.io',
+  String $gpg_key_filename = 'jenkins.io.key',
+) {
   assert_private()
 
   if $::jenkins::repo {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -2,33 +2,21 @@
 # jenkins::repo handles pulling in the platform specific repo classes
 #
 class jenkins::repo {
-  anchor { 'jenkins::repo::begin': }
-  anchor { 'jenkins::repo::end': }
-
   assert_private()
 
-  if ( $::jenkins::repo ) {
+  if $::jenkins::repo {
     case $::osfamily {
 
       'RedHat', 'Linux': {
-        class { 'jenkins::repo::el': }
-        Anchor['jenkins::repo::begin']
-          -> Class['jenkins::repo::el']
-          -> Anchor['jenkins::repo::end']
+        contain jenkins::repo::el
       }
 
       'Debian': {
-        class { 'jenkins::repo::debian': }
-        Anchor['jenkins::repo::begin']
-          -> Class['jenkins::repo::debian']
-          -> Anchor['jenkins::repo::end']
+        contain jenkins::repo::debian
       }
 
       'Suse' : {
-        class { 'jenkins::repo::suse': }
-        Anchor['jenkins::repo::begin']
-          -> Class['jenkins::repo::suse']
-          -> Anchor['jenkins::repo::end']
+        contain jenkins::repo::suse
       }
 
       default: {

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -36,8 +36,4 @@ class jenkins::repo::debian
       },
     }
   }
-
-  anchor { 'jenkins::repo::debian::begin': }
-    -> Apt::Source['jenkins']
-    -> anchor { 'jenkins::repo::debian::end': }
 }

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -1,39 +1,28 @@
 # Class: jenkins::repo::debian
 #
-class jenkins::repo::debian
-{
+class jenkins::repo::debian (
+  String $gpg_key_id = '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+) {
   assert_private()
 
   include apt
 
-  $pkg_host = 'https://pkg.jenkins.io'
-
-  if $::jenkins::lts  {
-    apt::source { 'jenkins':
-      location => "${pkg_host}/debian-stable",
-      release  => 'binary/',
-      repos    => '',
-      include  => {
-        'src' => false,
-      },
-      key      => {
-        'id'     => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-        'source' => "${pkg_host}/debian/jenkins-ci.org.key",
-      },
-    }
+  if $jenkins::lts {
+    $location = "${jenkins::repo::base_url}/debian-stable"
+  } else {
+    $location = "${jenkins::repo::base_url}/debian"
   }
-  else {
-    apt::source { 'jenkins':
-      location => "${pkg_host}/debian",
-      release  => 'binary/',
-      repos    => '',
-      include  => {
-        'src' => false,
-      },
-      key      => {
-        'id'     => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-        'source' => "${pkg_host}/debian/jenkins-ci.org.key",
-      },
-    }
+
+  apt::source { 'jenkins':
+    location => $location,
+    release  => 'binary/',
+    repos    => '',
+    include  => {
+      'src' => false,
+    },
+    key      => {
+      'id'     => $gpg_key_id,
+      'source' => "${location}/${jenkins::repo::gpg_key_filename}",
+    },
   }
 }

--- a/manifests/repo/el.pp
+++ b/manifests/repo/el.pp
@@ -1,30 +1,20 @@
 # Class: jenkins::repo::el
 #
-class jenkins::repo::el
-{
+class jenkins::repo::el {
   assert_private()
 
-  $repo_proxy = $::jenkins::repo_proxy
-
-  if $::jenkins::lts  {
-    yumrepo {'jenkins':
-      descr    => 'Jenkins',
-      baseurl  => 'https://pkg.jenkins.io/redhat-stable/',
-      gpgcheck => 1,
-      gpgkey   => 'https://pkg.jenkins.io/redhat/jenkins-ci.org.key',
-      enabled  => 1,
-      proxy    => $repo_proxy,
-    }
+  if $jenkins::lts {
+    $baseurl = "${jenkins::repo::base_url}/redhat-stable/"
+  } else {
+    $baseurl = "${jenkins::repo::base_url}/redhat/"
   }
 
-  else {
-    yumrepo {'jenkins':
-      descr    => 'Jenkins',
-      baseurl  => 'https://pkg.jenkins.io/redhat/',
-      gpgcheck => 1,
-      gpgkey   => 'https://pkg.jenkins.io/redhat/jenkins-ci.org.key',
-      enabled  => 1,
-      proxy    => $repo_proxy,
-    }
+  yumrepo {'jenkins':
+    descr    => 'Jenkins',
+    baseurl  => $baseurl,
+    gpgcheck => 1,
+    gpgkey   => "${baseurl}${jenkins::repo::gpg_key_filename}",
+    enabled  => 1,
+    proxy    => $jenkins::repo_proxy,
   }
 }

--- a/manifests/repo/suse.pp
+++ b/manifests/repo/suse.pp
@@ -1,22 +1,18 @@
 # Class: jenkins::repo::suse
 #
-class jenkins::repo::suse
-{
+class jenkins::repo::suse {
   assert_private()
 
-  if $::jenkins::lts {
-    zypprepo {'jenkins':
-      descr    => 'Jenkins',
-      baseurl  => 'https://pkg.jenkins.io/opensuse-stable/',
-      gpgcheck => 1,
-      gpgkey   => 'https://pkg.jenkins.io/redhat/jenkins-ci.org.key',
-    }
+  if $jenkins::lts {
+    $baseurl = "${jenkins::repo::base_url}/opensuse-stable/"
   } else {
-    zypprepo {'jenkins':
-      descr    => 'Jenkins',
-      baseurl  => 'https://pkg.jenkins.io/opensuse/',
-      gpgcheck => 1,
-      gpgkey   => 'https://pkg.jenkins.io/redhat/jenkins-ci.org.key',
-    }
+    $baseurl = "${jenkins::repo::base_url}/opensuse/"
+  }
+
+  zypprepo {'jenkins':
+    descr    => 'Jenkins',
+    baseurl  => $baseurl,
+    gpgcheck => 1,
+    gpgkey   => "${baseurl}${jenkins::repo::gpg_key_filename}",
   }
 }

--- a/spec/classes/jenkins_repo_spec.rb
+++ b/spec/classes/jenkins_repo_spec.rb
@@ -18,13 +18,16 @@ describe 'jenkins', type: :class do
           case facts[:os]['family']
           when 'RedHat'
             describe 'RedHat' do
+              it { is_expected.to compile.with_all_deps }
               it { is_expected.to contain_class('jenkins::repo::el') }
               it { is_expected.not_to contain_class('jenkins::repo::suse') }
               it { is_expected.not_to contain_class('jenkins::repo::debian') }
+              it { is_expected.to contain_package('jenkins').that_requires('Yumrepo[jenkins]') }
             end
             describe 'repo => false' do
               let(:params) { { repo: false } }
 
+              it { is_expected.to compile.with_all_deps }
               it { is_expected.not_to contain_class('jenkins::repo') }
               it { is_expected.not_to contain_class('jenkins::repo::el') }
               it { is_expected.not_to contain_class('jenkins::repo::suse') }
@@ -32,15 +35,19 @@ describe 'jenkins', type: :class do
             end
           when 'Suse'
             describe 'Suse' do
+              it { is_expected.to compile.with_all_deps }
               it { is_expected.to contain_class('jenkins::repo::suse') }
               it { is_expected.not_to contain_class('jenkins::repo::el') }
               it { is_expected.not_to contain_class('jenkins::repo::debian') }
+              it { is_expected.to contain_package('jenkins').that_requires('Zypprepo[jenkins]') }
             end
           when 'Debian'
             describe 'Debian' do
+              it { is_expected.to compile.with_all_deps }
               it { is_expected.to contain_class('jenkins::repo::debian') }
               it { is_expected.not_to contain_class('jenkins::repo::suse') }
               it { is_expected.not_to contain_class('jenkins::repo::el') }
+              it { is_expected.to contain_package('jenkins').that_requires('Apt::Source[jenkins]') }
             end
           end
         end


### PR DESCRIPTION
See the individual commits for details:

* Simplify repository handling for distros
* Use contain over anchors
* Rely on puppetlabs-apt $notify_update
* Rely on puppetlabs-apt for apt-transport-https
* Use assert_private() from stdlib
* Do not include the stdlib class