### PR TITLE
Allow custom location for slave JAVA command

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -87,13 +87,15 @@
 #   can be a String, or an Array.
 #
 # [*proxy_server*]
-#
 #   Serves the same function as `::jenkins::proxy_server` but is an independent
 #   parameter so the `::jenkins` class does not need to be the catalog for
 #   slave only nodes.
 #
 # [*swarm_client_args*]
 #   Swarm client arguments to add to slave command line. More info: https://github.com/jenkinsci/swarm-plugin/blob/master/client/src/main/java/hudson/plugins/swarm/Options.java
+#
+# [*java_cmd*]
+#   Path to the java command in ${defaults_location}/jenkins-slave. Defaults to '/usr/bin/java'
 #
 
 # === Examples
@@ -140,6 +142,7 @@ class jenkins::slave (
   Any $java_args                          = undef,
   Any $swarm_client_args                  = undef,
   Boolean $delete_existing_clients        = false,
+  Any $java_cmd                           = '/usr/bin/java',
 ) inherits jenkins::params {
 
   if versioncmp($version, '3.0') < 0 {

--- a/spec/classes/jenkins_slave_spec.rb
+++ b/spec/classes/jenkins_slave_spec.rb
@@ -253,6 +253,13 @@ describe 'jenkins::slave' do
             end
           end
         end # delete_existing_clients
+
+        describe 'with a non-default $java_cmd' do
+          let(:params) { { java_cmd: '/usr/local/bin/java' } }
+
+          it { is_expected.to contain_file(slave_runtime_file).with_content(%r{^JAVA="#{java_cmd}"$}) }
+        end
+
       end
 
       shared_examples 'using slave_name' do

--- a/templates/jenkins-slave-defaults.erb
+++ b/templates/jenkins-slave-defaults.erb
@@ -4,7 +4,7 @@
 # this file can not be used in its current state as a systemd EnvironmentFile.
 
 # location of java
-JAVA=/usr/bin/java
+JAVA=<%= @java_cmd %>
 
 # arguments to pass to java
 #JAVA_ARGS="-Xmx256m"


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Allow overriding the default Java command in jenkins-slave-defaults.erb (e.g. /etc/sysconfig/jenkins-slave).  This enables the use of a different Java version than the default system java.

#### This Pull Request (PR) fixes the following issues
n/a

