### PR TITLE
Pass java_cmd to start_slave.sh (OS X)

### DIFF
--- a/templates/start-slave.sh.erb
+++ b/templates/start-slave.sh.erb
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 source <%= @defaults_location %>/jenkins-slave 
-java -jar <%= @slave_home %>/<%= @client_jar %> $JENKINS_SLAVE_ARGS
+$JAVA -jar <%= @slave_home %>/<%= @client_jar %> $JENKINS_SLAVE_ARGS


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Passes the custom JAVA command (java_cmd) to the OS X slave startup script.

#### This Pull Request (PR) fixes the following issues
n/a
