### PR TITLE
split examples about error and idempotency as much as possible

### DIFF
--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -4,16 +4,14 @@ describe 'jenkins class' do
   include_context 'jenkins'
 
   context 'default parameters' do
-    it 'works with no errors' do
-      pp = <<-EOS
-      class {'jenkins':
-        cli_remoting_free => true,
-        cli               => true,
-      }
-      EOS
+    pp = <<-EOS
+    class {'jenkins':
+      cli_remoting_free => true,
+      cli               => true,
+    }
+    EOS
 
-      apply2(pp)
-    end
+    apply2(pp)
 
     describe port(8080) do
       it {
@@ -66,16 +64,14 @@ describe 'jenkins class' do
   end # default parameters
 
   context 'executors' do
-    it 'works with no errors' do
-      pp = <<-EOS
-      class {'jenkins':
-        executors         => 42,
-        cli_remoting_free => true,
-      }
-      EOS
+    pp = <<-EOS
+    class {'jenkins':
+      executors         => 42,
+      cli_remoting_free => true,
+    }
+    EOS
 
-      apply2(pp)
-    end
+    apply2(pp)
 
     describe port(8080) do
       # jenkins should already have been running so we shouldn't have to
@@ -94,16 +90,14 @@ describe 'jenkins class' do
   end # executors
 
   context 'slaveagentport' do
-    it 'works with no errors' do
-      pp = <<-EOS
-        class {'jenkins':
-          slaveagentport    => 7777,
-          cli_remoting_free => true,
-        }
-        EOS
+    pp = <<-EOS
+      class {'jenkins':
+        slaveagentport    => 7777,
+        cli_remoting_free => true,
+      }
+      EOS
 
-      apply2(pp)
-    end
+    apply2(pp)
 
     describe port(8080) do
       # jenkins should already have been running so we shouldn't have to

--- a/spec/acceptance/plugin_spec.rb
+++ b/spec/acceptance/plugin_spec.rb
@@ -39,20 +39,18 @@ describe 'jenkins class', order: :defined do
   end
 
   context 'default parameters' do
-    it 'works with no errors' do
-      pp = <<-EOS
-      class {'jenkins':
-        cli_remoting_free => true,
-      }
+    pp = <<-EOS
+    class {'jenkins':
+      cli_remoting_free => true,
+    }
 
-      jenkins::plugin {'git-plugin':
-        name    => 'git',
-        version => '2.3.4',
-      }
-      EOS
+    jenkins::plugin {'git-plugin':
+      name    => 'git',
+      version => '2.3.4',
+    }
+    EOS
 
-      apply2(pp)
-    end
+    apply2(pp)
 
     it_behaves_like 'has_git_plugin'
   end
@@ -70,7 +68,9 @@ describe 'jenkins class', order: :defined do
         version => '2.3.4',
       }
       EOS
-      apply2(pp)
+
+      apply(pp, catch_failures: true)
+      apply(pp, catch_changes: true)
     end
 
     context 'downgrade' do
@@ -80,17 +80,20 @@ describe 'jenkins class', order: :defined do
           package{'unzip':
             ensure => present
           }
-        class {'jenkins':
-          cli_remoting_free => true,
-          purge_plugins     => true,
-        }
+          class {'jenkins':
+            cli_remoting_free => true,
+            purge_plugins     => true,
+          }
 
-        jenkins::plugin {'git-plugin':
-          name    => 'git',
-          version => '1.0',
-        }
-        EOS
-          apply2(pp)
+          jenkins::plugin {'git-plugin':
+            name    => 'git',
+            version => '1.0',
+          }
+          EOS
+
+          apply(pp, catch_failures: true)
+          apply(pp, catch_changes: true)
+
           # Find the version of the installed git plugin
           git_version = shell("unzip -p #{$pdir}/git.hpi META-INF/MANIFEST.MF | sed 's/Plugin-Version: \\\(.*\\\)/\\1/;tx;d;:x'").stdout.strip
           git_version.should eq('1.0')
@@ -116,7 +119,8 @@ describe 'jenkins class', order: :defined do
         }
         EOS
 
-        apply2(pp)
+        apply(pp, catch_failures: true)
+        apply(pp, catch_changes: true)
       end
 
       it_behaves_like 'has_git_plugin'
@@ -144,7 +148,8 @@ describe 'jenkins class', order: :defined do
         }
         EOS
 
-        apply2(pp)
+        apply(pp, catch_failures: true)
+        apply(pp, catch_changes: true)
       end
 
       it_behaves_like 'has_git_plugin'

--- a/spec/acceptance/slave_spec.rb
+++ b/spec/acceptance/slave_spec.rb
@@ -4,13 +4,11 @@ describe 'jenkins::slave class' do
   include_context 'jenkins'
 
   context 'default parameters' do
-    it 'works with no errors' do
-      pp = <<-EOS
-        include ::jenkins::slave
-      EOS
+    pp = <<-EOS
+      include ::jenkins::slave
+    EOS
 
-      apply2(pp)
-    end
+    apply2(pp)
 
     if $systemd
       describe file('/etc/systemd/system/jenkins-slave.service') do
@@ -60,16 +58,14 @@ describe 'jenkins::slave class' do
     end
 
     context 'ui_user/ui_pass' do
-      it 'works with no errors' do
-        pp = <<-EOS
-          class { ::jenkins::slave:
-            ui_user => 'imauser',
-            ui_pass => 'imapass',
-          }
-        EOS
+      pp = <<-EOS
+        class { ::jenkins::slave:
+          ui_user => 'imauser',
+          ui_pass => 'imapass',
+        }
+      EOS
 
-        apply2(pp)
-      end
+      apply2(pp)
 
       describe process('java') do
         its(:user) { is_expected.to eq 'jenkins-slave' }
@@ -81,15 +77,13 @@ describe 'jenkins::slave class' do
 
     context 'disable_clients_unique_id' do
       context 'true' do
-        it 'works with no errors' do
-          pp = <<-EOS
-            class { ::jenkins::slave:
-              disable_clients_unique_id => true,
-            }
-          EOS
+        pp = <<-EOS
+          class { ::jenkins::slave:
+            disable_clients_unique_id => true,
+          }
+        EOS
 
-          apply2(pp)
-        end
+        apply2(pp)
 
         describe process('java') do
           its(:user) { is_expected.to eq 'jenkins-slave' }
@@ -98,15 +92,13 @@ describe 'jenkins::slave class' do
       end # true
 
       context 'false' do
-        it 'works with no errors' do
-          pp = <<-EOS
-            class { ::jenkins::slave:
-              disable_clients_unique_id => false,
-            }
-          EOS
+        pp = <<-EOS
+          class { ::jenkins::slave:
+            disable_clients_unique_id => false,
+          }
+        EOS
 
-          apply2(pp)
-        end
+        apply2(pp)
 
         describe process('java') do
           its(:user) { is_expected.to eq 'jenkins-slave' }
@@ -117,15 +109,13 @@ describe 'jenkins::slave class' do
 
     context 'disable_ssl_verification' do
       context 'true' do
-        it 'works with no errors' do
-          pp = <<-EOS
-            class { ::jenkins::slave:
-              disable_ssl_verification => true,
-            }
-          EOS
+        pp = <<-EOS
+          class { ::jenkins::slave:
+            disable_ssl_verification => true,
+          }
+        EOS
 
-          apply2(pp)
-        end
+        apply2(pp)
 
         describe process('java') do
           its(:user) { is_expected.to eq 'jenkins-slave' }
@@ -134,15 +124,13 @@ describe 'jenkins::slave class' do
       end # true
 
       context 'false' do
-        it 'works with no errors' do
-          pp = <<-EOS
-            class { ::jenkins::slave:
-              disable_ssl_verification => false,
-            }
-          EOS
+        pp = <<-EOS
+          class { ::jenkins::slave:
+            disable_ssl_verification => false,
+          }
+        EOS
 
-          apply2(pp)
-        end
+        apply2(pp)
 
         describe process('java') do
           its(:user) { is_expected.to eq 'jenkins-slave' }
@@ -153,15 +141,13 @@ describe 'jenkins::slave class' do
 
     context 'delete_existing_clients' do
       context 'true' do
-        it 'works with no errors' do
-          pp = <<-EOS
-            class { ::jenkins::slave:
-              delete_existing_clients => true,
-            }
-          EOS
+        pp = <<-EOS
+          class { ::jenkins::slave:
+            delete_existing_clients => true,
+          }
+        EOS
 
-          apply2(pp)
-        end
+        apply2(pp)
 
         describe process('java') do
           its(:user) { is_expected.to eq 'jenkins-slave' }
@@ -170,15 +156,13 @@ describe 'jenkins::slave class' do
       end # true
 
       context 'false' do
-        it 'works with no errors' do
-          pp = <<-EOS
-            class { ::jenkins::slave:
-              delete_existing_clients => false,
-            }
-          EOS
+        pp = <<-EOS
+          class { ::jenkins::slave:
+            delete_existing_clients => false,
+          }
+        EOS
 
-          apply2(pp)
-        end
+        apply2(pp)
 
         describe process('java') do
           its(:user) { is_expected.to eq 'jenkins-slave' }
@@ -189,15 +173,13 @@ describe 'jenkins::slave class' do
 
     context 'labels' do
       context 'single label in string' do
-        it 'works with no errors' do
-          pp = <<-EOS
-            class { ::jenkins::slave:
-              labels => 'foo',
-            }
-          EOS
+        pp = <<-EOS
+          class { ::jenkins::slave:
+            labels => 'foo',
+          }
+        EOS
 
-          apply2(pp)
-        end
+        apply2(pp)
 
         describe process('java') do
           its(:user) { is_expected.to eq 'jenkins-slave' }
@@ -206,15 +188,13 @@ describe 'jenkins::slave class' do
       end
 
       context 'multiple labels in string' do
-        it 'works with no errors' do
-          pp = <<-EOS
-            class { ::jenkins::slave:
-              labels => 'foo bar baz',
-            }
-          EOS
+        pp = <<-EOS
+          class { ::jenkins::slave:
+            labels => 'foo bar baz',
+          }
+        EOS
 
-          apply2(pp)
-        end
+        apply2(pp)
 
         describe process('java') do
           its(:user) { is_expected.to eq 'jenkins-slave' }
@@ -223,15 +203,13 @@ describe 'jenkins::slave class' do
       end
 
       context 'multiple labels in array' do
-        it 'works with no errors' do
-          pp = <<-EOS
-            class { ::jenkins::slave:
-              labels => ['foo', 'bar', 'baz'],
-            }
-          EOS
+        pp = <<-EOS
+          class { ::jenkins::slave:
+            labels => ['foo', 'bar', 'baz'],
+          }
+        EOS
 
-          apply2(pp)
-        end
+        apply2(pp)
 
         describe process('java') do
           its(:user) { is_expected.to eq 'jenkins-slave' }
@@ -244,15 +222,13 @@ describe 'jenkins::slave class' do
       tool_locations = 'Python-2.7:/usr/bin/python2.7 Java-1.8:/usr/bin/java'
 
       context tool_locations do
-        it 'works with no errors' do
-          pp = <<-EOS
-            class { ::jenkins::slave:
-              tool_locations => '#{tool_locations}',
-            }
-          EOS
+        pp = <<-EOS
+          class { ::jenkins::slave:
+            tool_locations => '#{tool_locations}',
+          }
+        EOS
 
-          apply2(pp)
-        end
+        apply2(pp)
 
         describe process('java') do
           its(:user) { is_expected.to eq 'jenkins-slave' }
@@ -266,15 +242,13 @@ describe 'jenkins::slave class' do
       tunnel = 'localhost:9000'
 
       context tunnel do
-        it 'works with no errors' do
-          pp = <<-EOS
-            class { ::jenkins::slave:
-              tunnel => '#{tunnel}',
-            }
-          EOS
+        pp = <<-EOS
+          class { ::jenkins::slave:
+            tunnel => '#{tunnel}',
+          }
+        EOS
 
-          apply2(pp)
-        end
+        apply2(pp)
 
         describe process('java') do
           its(:user) { is_expected.to eq 'jenkins-slave' }

--- a/spec/acceptance/xtypes/jenkins_credentials_spec.rb
+++ b/spec/acceptance/xtypes/jenkins_credentials_spec.rb
@@ -6,7 +6,7 @@ describe 'jenkins_credentials' do
   context 'ensure =>' do
     context 'present' do
       context 'UsernamePasswordCredentialsImpl' do
-        it 'works with no errors' do
+        it 'works with no errors and idempotently' do
           pp = base_manifest + <<-EOS
             jenkins_credentials { '9b07d668-a87e-4877-9407-ae05056e32ac':
               ensure      => 'present',
@@ -19,7 +19,8 @@ describe 'jenkins_credentials' do
             }
           EOS
 
-          apply2(pp)
+          apply(pp, catch_failures: true)
+          apply(pp, catch_changes: true)
         end
 
         describe file('/var/lib/jenkins/credentials.xml') do
@@ -31,7 +32,7 @@ describe 'jenkins_credentials' do
       end
 
       context 'ConduitCredentialsImpl' do
-        it 'works with no errors' do
+        it 'works with no errors and idempotently' do
           pending('puppet_helper.groovy implementation missing, see https://github.com/jenkinsci/puppet-jenkins/issues/753')
           pp = base_manifest + <<-EOS
             jenkins_credentials { '002224bd-60cb-49f3-a314-d0f73f82233d':
@@ -44,8 +45,10 @@ describe 'jenkins_credentials' do
             }
           EOS
 
-          apply2(pp)
+          apply(pp, catch_failures: true)
+          apply(pp, catch_changes: true)
         end
+
         # XXX need to properly compare the XML doc
         # trying to match anything other than the id this way might match other
         # credentials
@@ -58,7 +61,7 @@ describe 'jenkins_credentials' do
       end
 
       context 'BasicSSHUserPrivateKey' do
-        it 'works with no errors' do
+        it 'works with no errors and idempotently' do
           pp = base_manifest + <<-EOS
             jenkins::plugin { 'ssh-credentials': }
 
@@ -74,7 +77,8 @@ describe 'jenkins_credentials' do
             }
           EOS
 
-          apply2(pp)
+          apply(pp, catch_failures: true)
+          apply(pp, catch_changes: true)
         end
 
         describe file('/var/lib/jenkins/credentials.xml') do
@@ -86,7 +90,7 @@ describe 'jenkins_credentials' do
       end
 
       context 'StringCredentialsImpl' do
-        it 'works with no errors' do
+        it 'works with no errors and idempotently' do
           pp = base_manifest + <<-EOS
             jenkins::plugin { 'plain-credentials':
               pin => true,
@@ -102,7 +106,8 @@ describe 'jenkins_credentials' do
             }
           EOS
 
-          apply2(pp)
+          apply(pp, catch_failures: true)
+          apply(pp, catch_changes: true)
         end
 
         describe file('/var/lib/jenkins/credentials.xml') do
@@ -114,7 +119,7 @@ describe 'jenkins_credentials' do
       end
 
       context 'FileCredentialsImpl' do
-        it 'works with no errors' do
+        it 'works with no errors and idempotently' do
           pp = base_manifest + <<-EOS
             jenkins::plugin { 'plain-credentials':
               pin => true,
@@ -131,7 +136,8 @@ describe 'jenkins_credentials' do
             }
           EOS
 
-          apply2(pp)
+          apply(pp, catch_failures: true)
+          apply(pp, catch_changes: true)
         end
 
         describe file('/var/lib/jenkins/credentials.xml') do
@@ -143,7 +149,7 @@ describe 'jenkins_credentials' do
       end
 
       context 'AWSCredentialsImpl' do
-        it 'works with no errors' do
+        it 'works with no errors and idempotently' do
           pending('jenkins plugin tests are not consistently failing or succeeding: https://github.com/voxpupuli/puppet-jenkins/issues/839')
           pp = base_manifest + <<-EOS
             jenkins::plugin { [
@@ -165,7 +171,8 @@ describe 'jenkins_credentials' do
             }
           EOS
 
-          apply2(pp)
+          apply(pp, catch_failures: true)
+          apply(pp, catch_changes: true)
         end
 
         describe file('/var/lib/jenkins/credentials.xml') do
@@ -180,7 +187,7 @@ describe 'jenkins_credentials' do
       end
 
       context 'GitLabApiTokenImpl' do
-        it 'works with no errors' do
+        it 'works with no errors and idempotently' do
           pending('jenkins plugin tests are not consistently failing or succeeding: https://github.com/voxpupuli/puppet-jenkins/issues/839')
           pp = base_manifest + <<-EOS
             package { 'git': }
@@ -210,7 +217,8 @@ describe 'jenkins_credentials' do
             }
           EOS
 
-          apply2(pp)
+          apply(pp, catch_failures: true)
+          apply(pp, catch_changes: true)
         end
 
         describe file('/var/lib/jenkins/credentials.xml') do
@@ -225,7 +233,7 @@ describe 'jenkins_credentials' do
       end
 
       context 'GoogleRobotPrivateKeyCredentials with json_key' do
-        it 'works with no errors' do
+        it 'works with no errors and idempotently' do
           pending('jenkins plugin tests are not consistently failing or succeeding: https://github.com/voxpupuli/puppet-jenkins/issues/839')
           pp = base_manifest + <<-EOS
             jenkins::plugin { [
@@ -247,7 +255,8 @@ describe 'jenkins_credentials' do
             }
           EOS
 
-          apply2(pp)
+          apply(pp, catch_failures: true)
+          apply(pp, catch_changes: true)
         end
 
         describe file('/var/lib/jenkins/credentials.xml') do
@@ -262,7 +271,7 @@ describe 'jenkins_credentials' do
       end
 
       context 'GoogleRobotPrivateKeyCredentials with email_address and p12_key' do
-        it 'works with no errors' do
+        it 'works with no errors and idempotently' do
           pending('jenkins plugin tests are not consistently failing or succeeding: https://github.com/voxpupuli/puppet-jenkins/issues/839')
           pp = base_manifest + <<-EOS
             jenkins::plugin { [
@@ -280,7 +289,8 @@ describe 'jenkins_credentials' do
             }
           EOS
 
-          apply2(pp)
+          apply(pp, catch_failures: true)
+          apply(pp, catch_changes: true)
         end
 
         describe file('/var/lib/jenkins/credentials.xml') do
@@ -295,7 +305,7 @@ describe 'jenkins_credentials' do
       end
 
       context 'BrowserStackCredentials' do
-        it 'works with no errors' do
+        it 'works with no errors and idempotently' do
           pending('jenkins plugin tests are not consistently failing or succeeding: https://github.com/voxpupuli/puppet-jenkins/issues/839')
           pp = base_manifest + <<-EOS
             jenkins::plugin { [
@@ -316,7 +326,8 @@ describe 'jenkins_credentials' do
             }
           EOS
 
-          apply2(pp)
+          apply(pp, catch_failures: true)
+          apply(pp, catch_changes: true)
         end
 
         describe file('/var/lib/jenkins/credentials.xml') do
@@ -333,7 +344,7 @@ describe 'jenkins_credentials' do
 
     context 'absent' do
       context 'StringCredentialsImpl' do
-        it 'works with no errors' do
+        it 'works with no errors and idempotently' do
           pp = base_manifest + <<-EOS
             jenkins::plugin { 'plain-credentials': }
 
@@ -347,7 +358,8 @@ describe 'jenkins_credentials' do
             }
           EOS
 
-          apply2(pp)
+          apply(pp, catch_failures: true)
+          apply(pp, catch_changes: true)
         end
 
         describe file('/var/lib/jenkins/credentials.xml') do
@@ -359,7 +371,7 @@ describe 'jenkins_credentials' do
       end
 
       context 'FileCredentialsImpl' do
-        it 'works with no errors' do
+        it 'works with no errors and idempotently' do
           pp = base_manifest + <<-EOS
             jenkins::plugin { 'plain-credentials':
               pin => true,
@@ -376,7 +388,8 @@ describe 'jenkins_credentials' do
             }
           EOS
 
-          apply2(pp)
+          apply(pp, catch_failures: true)
+          apply(pp, catch_changes: true)
         end
 
         describe file('/var/lib/jenkins/credentials.xml') do

--- a/spec/acceptance/xtypes/jenkins_job_spec.rb
+++ b/spec/acceptance/xtypes/jenkins_job_spec.rb
@@ -81,14 +81,15 @@ EOS
     end # 'present' do
 
     context 'absent' do
-      it 'works with no errors' do
+      it 'works with no errors and idempotently' do
         pp = base_manifest + <<-EOS
           jenkins_job { 'foo':
             ensure => absent,
           }
         EOS
 
-        apply2(pp)
+        apply(pp, catch_failures: true)
+        apply(pp, catch_changes: true)
       end
 
       describe file('/var/lib/jenkins/jobs/foo/config.xml') do
@@ -151,14 +152,15 @@ EOS
       end # create
 
       context 'delete' do
-        it 'works with no errors' do
+        it 'works with no errors and idempotently' do
           pp = manifest + <<-EOS
             jenkins_job { 'foo': ensure => absent }
             jenkins_job { 'foo/bar': ensure => absent }
             jenkins_job { 'foo/bar/baz': ensure => absent }
           EOS
 
-          apply2(pp)
+          apply(pp, catch_failures: true)
+          apply(pp, catch_changes: true)
         end
 
         %w[

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -62,8 +62,12 @@ end
 
 # Run it twice and test for idempotency
 def apply2(pp)
-  apply(pp, catch_failures: true)
-  apply(pp, catch_changes: true)
+  it 'works with no error' do
+    apply_manifest(pp, catch_failures: true)
+  end
+  it 'works idempotently' do
+    apply_manifest(pp, catch_changes: true)
+  end
 end
 
 # probe stolen from:


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This module has a large amount of acceptance code. And failing due to error on apply or due to  idempotency issue will trigger same message about failure with `works with no errors`.

The PR try to split as much as possible failing with messages:
 * `works with no errors` : when fail is only due to error.
 * `works idempotently` : when fail is only due to idempotency issue.
 * `works with no errors and idempotently` : when i was unable to split.

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
