### PR TITLE
Use native Puppet instead of the retries Gem in the CLI provider, replacing try_sleep parameter by exponential backoff

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,7 +1,3 @@
 ---
-Gemfile:
-  optional:
-    ':test':
-      - gem: 'retries'
 .rubocop.yml:
   unmanaged: true

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ group :test do
   gem 'coveralls',                  :require => false
   gem 'simplecov-console',          :require => false
   gem 'puppet_metadata', '~> 3.5',  :require => false
-  gem 'retries',                    :require => false
 end
 
 group :development do

--- a/NATIVE_TYPES_AND_PROVIDERS.md
+++ b/NATIVE_TYPES_AND_PROVIDERS.md
@@ -121,8 +121,6 @@ class { '::jenkins':
 include ::jenkins::cli_helper
 ```
 
-The ruby gem `retries` is presently required by all providers.
-
 ### `puppetserver`
 
 There is a known issue with `puppetserver` being unable to load code from
@@ -140,13 +138,6 @@ jruby-puppet: {
 ```
 
 See [SERVER-973](https://tickets.puppetlabs.com/browse/SERVER-973)
-
-Additionally, the `retries` gem is required.  This may be installed on the master by running:
-
-```
-/opt/puppetlabs/bin/puppetserver gem install retries
-```
-
 
 Types
 --

--- a/lib/puppet/feature/retries.rb
+++ b/lib/puppet/feature/retries.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-require 'puppet/util/feature'
-
-Puppet.features.add(:retries, libs: 'retries')

--- a/lib/puppet/x/jenkins/config.rb
+++ b/lib/puppet/x/jenkins/config.rb
@@ -18,7 +18,6 @@ class Puppet::X::Jenkins::Config
     ssh_private_key: nil,
     puppet_helper: '/usr/share/java/puppet_helper.groovy',
     cli_tries: 30,
-    cli_try_sleep: 2,
     cli_username: nil,
     cli_password: nil,
     cli_password_file: '/tmp/jenkins_credentials_for_puppet',

--- a/lib/puppet/x/jenkins/provider/cli.rb
+++ b/lib/puppet/x/jenkins/provider/cli.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'puppet/provider'
+require 'puppet/util/retry_action'
 require 'facter'
 
 require 'json'
@@ -31,7 +32,6 @@ class Puppet::X::Jenkins::Provider::Cli < Puppet::Provider
   initvars
 
   commands java: 'java'
-  confine feature: :retries
 
   # subclasses should inherit this value once it has been determined that
   # jenkins requires authorization, it shortens the run time be elemating the
@@ -170,7 +170,6 @@ class Puppet::X::Jenkins::Provider::Cli < Puppet::Provider
     url                      = config[:url]
     ssh_private_key          = config[:ssh_private_key]
     cli_tries                = config[:cli_tries]
-    cli_try_sleep            = config[:cli_try_sleep]
     cli_username             = config[:cli_username]
     cli_password             = config[:cli_password]
     cli_password_file        = config[:cli_password_file]
@@ -202,16 +201,7 @@ class Puppet::X::Jenkins::Provider::Cli < Puppet::Provider
     # retry on "unknown" execution errors but don't catch AuthErrors.  If an
     # AuthError has bubbled up to this level it means either an ssh_private_key
     # is required and we don't have one or that one we have was rejected.
-    handler = proc do |exception, attempt_number, total_delay|
-      Puppet.debug("#{sname} caught #{exception.class.to_s.match(%r{::([^:]+)$})[1]}; retry attempt #{attempt_number}; #{total_delay.round(3)} seconds have passed")
-    end
-    with_retries(
-      max_tries: cli_tries,
-      base_sleep_seconds: 1,
-      max_sleep_seconds: cli_try_sleep,
-      rescue: [UnknownError, NetError],
-      handler: handler
-    ) do
+    Puppet::Util::RetryAction.retry_action(retries: cli_tries, retry_exceptions: [UnknownError, NetError]) do
       result = execute_with_auth(cli_cmd, auth_cmd, options)
       Puppet.debug("#{sname} command stdout:\n#{result}") unless result == ''
       return result
@@ -262,7 +252,8 @@ class Puppet::X::Jenkins::Provider::Cli < Puppet::Provider
       'SEVERE: I/O error in channel CLI connection',
       'java.net.SocketException: Connection reset',
       'java.net.ConnectException: Connection refused',
-      'java.io.IOException: Failed to connect'
+      'java.io.IOException: Failed to connect',
+      'java.io.IOException: Server returned HTTP response code: 503'
     ]
 
     if options.key?(:tmpfile_as_param)

--- a/manifests/cli/config.pp
+++ b/manifests/cli/config.pp
@@ -17,27 +17,9 @@ class jenkins::cli::config (
   Boolean $cli_password_file_exists               = false,
   Optional[String] $ssh_private_key_content       = undef,
 ) {
-  if str2bool($facts['is_pe']) {
-    $gem_provider = 'pe_gem'
-    # lint:ignore:legacy_facts
-  } elsif $facts['rubysitedir'] and ('/opt/puppetlabs/puppet/lib/ruby' in $facts['rubysitedir']) {
-    # lint:endignore
-    # AIO puppet
-    $gem_provider = 'puppet_gem'
-  } else {
-    $gem_provider = 'gem'
-  }
-
   # lint:ignore:legacy_facts
   $is_root = $facts['id'] == 'root'
   # lint:endignore
-
-  # required by PuppetX::Jenkins::Provider::Clihelper base
-  if ! defined(Package['retries']) {
-    package { 'retries':
-      provider => $gem_provider,
-    }
-  }
 
   if $ssh_private_key and $ssh_private_key_content {
     file { $ssh_private_key:

--- a/spec/classes/cli/config_spec.rb
+++ b/spec/classes/cli/config_spec.rb
@@ -126,26 +126,6 @@ describe 'jenkins::cli::config' do
           end
         end
       end
-
-      describe 'package gem provider' do
-        context 'is_pe fact' do
-          context 'true' do
-            let :facts do
-              super().merge(is_pe: true)
-            end
-
-            it { is_expected.to contain_package('retries').with(provider: 'pe_gem') }
-          end
-
-          context 'false' do
-            let :facts do
-              super().merge(is_pe: false)
-            end
-
-            it { is_expected.to contain_package('retries').with(provider: 'gem') }
-          end
-        end
-      end
     end
   end
 end

--- a/spec/unit/puppet/x/jenkins/config_spec.rb
+++ b/spec/unit/puppet/x/jenkins/config_spec.rb
@@ -10,8 +10,7 @@ describe Puppet::X::Jenkins::Config do
     url: 'http://localhost:8080',
     ssh_private_key: nil,
     puppet_helper: '/usr/share/java/puppet_helper.groovy',
-    cli_tries: 30,
-    cli_try_sleep: 2
+    cli_tries: 30
   }.freeze
 
   shared_context 'facts' do
@@ -21,7 +20,6 @@ describe Puppet::X::Jenkins::Config do
       Facter.add(:jenkins_ssh_private_key) { setcode { 'fact.id_rsa' } }
       Facter.add(:jenkins_puppet_helper) { setcode { 'fact.groovy' } }
       Facter.add(:jenkins_cli_tries) { setcode { 22 } }
-      Facter.add(:jenkins_cli_try_sleep) { setcode { 33 } }
     end
   end
 
@@ -126,8 +124,7 @@ describe Puppet::X::Jenkins::Config do
               url: 'http://localhost:111',
               ssh_private_key: 'cat.id_rsa',
               puppet_helper: 'cat.groovy',
-              cli_tries: 222,
-              cli_try_sleep: 333
+              cli_tries: 222
             )
 
             catalog.add_resource jenkins

--- a/spec/unit/puppet/x/spec_jenkins_providers.rb
+++ b/spec/unit/puppet/x/spec_jenkins_providers.rb
@@ -8,19 +8,6 @@ shared_examples 'confines to cli dependencies' do
       described_class.confine_collection.instance_variable_get(:@confines)
     end
 
-    it 'has no matched confines' do
-      expect(described_class.confine_collection.summary).to eq({})
-    end
-
-    context 'feature :retries' do
-      it do
-        expect(confines).to include(
-          be_a(Puppet::Confine::Feature).
-          and(have_attributes(values: [:retries]))
-        )
-      end
-    end
-
     context 'commands :java' do
       it do
         expect(confines).to include(


### PR DESCRIPTION
Retries is only used by the CLI providers. Puppet itself also provides retry functionality. This avoids the need to ensure a gem is installed in the right environment, which may not even work if it's a disconnected environment.

This does ignore a parameter for the maximum time to sleep. I'm looking for feedback on how to best deal with this.