### PR TITLE
Default INFO logging makes jenkins cli output messages that are then …

### DIFF
--- a/lib/puppet/x/jenkins/provider/cli.rb
+++ b/lib/puppet/x/jenkins/provider/cli.rb
@@ -182,7 +182,8 @@ class Puppet::X::Jenkins::Provider::Cli < Puppet::Provider
     base_cmd = cli_pre_cmd + [
       command(:java),
       '-jar', cli_jar,
-      '-s', url
+      '-s', url,
+      '-logger', 'WARNING'
     ]
 
     cli_cmd = base_cmd + [command]

--- a/spec/unit/puppet/x/jenkins/provider/cli_spec.rb
+++ b/spec/unit/puppet/x/jenkins/provider/cli_spec.rb
@@ -317,7 +317,7 @@ describe Puppet::X::Jenkins::Provider::Cli do
     shared_examples 'uses default values' do
       it 'uses default values' do
         expect(described_class.superclass).to receive(:execute).with(
-          'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 foo',
+          'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 -logger WARNING foo',
           failonfail: true, combine: true
         )
 
@@ -328,7 +328,7 @@ describe Puppet::X::Jenkins::Provider::Cli do
     shared_examples 'uses fact values' do
       it 'uses fact values' do
         expect(described_class.superclass).to receive(:execute).with(
-          'java -jar fact.jar -s http://localhost:11 foo',
+          'java -jar fact.jar -s http://localhost:11 -logger WARNING foo',
           failonfail: true, combine: true
         )
 
@@ -339,7 +339,7 @@ describe Puppet::X::Jenkins::Provider::Cli do
     shared_examples 'uses catalog values' do
       it 'uses catalog values' do
         expect(described_class.superclass).to receive(:execute).with(
-          'java -jar cat.jar -s http://localhost:111 foo',
+          'java -jar cat.jar -s http://localhost:111 -logger WARNING foo',
           failonfail: true, combine: true
         )
 
@@ -414,7 +414,7 @@ describe Puppet::X::Jenkins::Provider::Cli do
         CLI_AUTH_ERRORS.each do |error|
           it 'does not retry cli on AuthError exception' do
             expect(described_class.superclass).to receive(:execute).with(
-              'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 foo',
+              'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 -logger WARNING foo',
               failonfail: true, combine: true
             ).and_raise(AuthError, error)
 
@@ -438,7 +438,7 @@ describe Puppet::X::Jenkins::Provider::Cli do
 
         it 'tries cli without auth first' do
           expect(described_class.superclass).to receive(:execute).with(
-            'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 foo',
+            'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 -logger WARNING foo',
             failonfail: true, combine: true
           )
 
@@ -448,12 +448,12 @@ describe Puppet::X::Jenkins::Provider::Cli do
         CLI_AUTH_ERRORS.each do |error|
           it 'retries cli on AuthError exception' do
             expect(described_class.superclass).to receive(:execute).with(
-              'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 foo',
+              'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 -logger WARNING foo',
               failonfail: true, combine: true
             ).and_raise(AuthError, error)
 
             expect(described_class.superclass).to receive(:execute).with(
-              'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 -i cat.id_rsa foo',
+              'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 -logger WARNING -i cat.id_rsa foo',
               failonfail: true, combine: true
             )
 
@@ -461,12 +461,12 @@ describe Puppet::X::Jenkins::Provider::Cli do
 
             # and it should remember that auth is required
             expect(described_class.superclass).not_to receive(:execute).with(
-              'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 foo',
+              'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 -logger WARNING foo',
               failonfail: true, combine: true
             )
 
             expect(described_class.superclass).to receive(:execute).with(
-              'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 -i cat.id_rsa foo',
+              'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 -logger WARNING -i cat.id_rsa foo',
               failonfail: true, combine: true
             )
 
@@ -481,7 +481,7 @@ describe Puppet::X::Jenkins::Provider::Cli do
         CLI_NET_ERRORS.each do |error|
           it 'does not retry cli on AuthError exception' do
             expect(described_class.superclass).to receive(:execute).with(
-              'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 foo',
+              'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 -logger WARNING foo',
               failonfail: true, combine: true
             ).exactly(30).times.and_raise(NetError, error)
 
@@ -504,7 +504,7 @@ describe Puppet::X::Jenkins::Provider::Cli do
           catalog.add_resource jenkins
 
           expect(described_class.superclass).to receive(:execute).with(
-            'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 foo',
+            'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 -logger WARNING foo',
             failonfail: true, combine: true
           ).exactly(30).times.and_raise(UnknownError, 'foo')
 
@@ -520,7 +520,7 @@ describe Puppet::X::Jenkins::Provider::Cli do
           catalog.add_resource jenkins
 
           expect(described_class.superclass).to receive(:execute).with(
-            'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 foo',
+            'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 -logger WARNING foo',
             failonfail: true, combine: true
           ).exactly(2).times.and_raise(UnknownError, 'foo')
 
@@ -537,7 +537,7 @@ describe Puppet::X::Jenkins::Provider::Cli do
           catalog.add_resource jenkins
 
           expect(described_class.superclass).to receive(:execute).with(
-            'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 foo',
+            'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 -logger WARNING foo',
             failonfail: true, combine: true
           ).exactly(3).times.and_raise(UnknownError, 'foo')
 
@@ -555,7 +555,7 @@ describe Puppet::X::Jenkins::Provider::Cli do
           catalog.add_resource jenkins
 
           expect(described_class.superclass).to receive(:execute).with(
-            'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 foo',
+            'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 -logger WARNING foo',
             failonfail: true, combine: true
           ).exactly(2).times.and_raise(UnknownError, 'foo')
 
@@ -652,7 +652,7 @@ describe Puppet::X::Jenkins::Provider::Cli do
         expect(tmp).to receive(:path) { '/dne.tmp' }
 
         expect(described_class.superclass).to receive(:execute).with(
-          'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 foo',
+          'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 -logger WARNING foo',
           failonfail: true,
           combine: true,
           stdinfile: '/dne.tmp'
@@ -674,7 +674,7 @@ describe Puppet::X::Jenkins::Provider::Cli do
         expect(tmp).to receive(:path) { '/dne.tmp' }
 
         expect(described_class.superclass).to receive(:execute).with(
-          'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 foo',
+          'java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 -logger WARNING foo',
           failonfail: true,
           combine: true,
           stdinfile: '/dne.tmp'


### PR DESCRIPTION
…evaluated as non-valid json

#### Pull Request (PR) description
After upgrading or setting up new jenkins masters based on the new jenkins LTS release 2.164.1, we noticed the same issues as mentioned in an earlier opened issue. Jenkins client jar gives back some "INFO" level messages when starting and when puppet tries to use that output combined with the real json, it of course sees that the total result is not valid json.

This PR make sure that only warning or worse messages get outputted by the jenkins-client.jar for usage with the puppet provider.

#### This Pull Request (PR) fixes the following issues
Fixes #905