### PR TITLE
Replace `merge` function with `+`

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -42,12 +42,12 @@ class jenkins::config {
   }
 
   $plugin_dir_params = $::jenkins::purge_plugins ? {
-    true    => merge($dir_params, {
+    true    => $dir_params + {
       'purge'   => true,
       'recurse' => true,
       'force'   => true,
-      'notify'  => Class['::jenkins::service'],
-    }),
+      'notify'  => Class['jenkins::service'],
+    },
     default => $dir_params,
   }
 


### PR DESCRIPTION
Latest stdlib (from git) has a new `merge` implementation.
https://github.com/puppetlabs/puppetlabs-stdlib/pull/1008

It appears to be broken for puppet 4.  We're planning to drop puppet 4
any moment, but for right now, replacing the call to `merge` with `+`
works fine.

Fixes

```
Puppet::PreformattedError:
       Evaluation Error: Error while evaluating a Function Call, 'merge' expects one of:
         (Variant[Hash, Undef, String[0, 0]] args*)
           rejected: parameter 'args' variant 0 entry 'notify' expects a value of type Undef or Data, got Type[Class]
           rejected: parameter 'args' variant 1 expects a value of type Undef or String, got Struct
         (Iterable args*, Callable[3, 3] block)
           rejected: expects a block
         (Iterable args*, Callable[2, 2] block)
           rejected: expects a block at /home/travis/build/voxpupuli/puppet-jenkins/spec/fixtures/modules/jenkins/manifests/config.pp:45:16
```
