### PR TITLE
Update metadata for Vox Pupuli release

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,15 +1,16 @@
 {
-  "name": "rtyler-jenkins",
+  "name": "puppet-jenkins",
   "version": "1.7.0",
   "author": "R. Tyler Croy <tyler@monkeypox.org>, Joshua Hoblitt <josh@hoblitt.com>",
   "license": "Apache-2.0",
   "summary": "Manage the Jenkins continuous integration service with Puppet",
-  "source": "https://github.com/jenkinsci/puppet-jenkins",
-  "project_page": "https://github.com/jenkinsci/puppet-jenkins",
-  "issues_url": "https://github.com/jenkinsci/puppet-jenkins/issues",
+  "source": "https://github.com/voxpupuli/puppet-jenkins",
+  "project_page": "https://github.com/voxpupuli/puppet-jenkins",
+  "issues_url": "https://github.com/voxpupuli/puppet-jenkins/issues",
   "tags": [
     "jenkins",
-    "jenkinsci"
+    "jenkinsci",
+    "voxpupuli"
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
Update urls and version numbers in the `metadata.json` file.