### PR TITLE
add output of facter command to know value of custom fact

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -61,12 +61,19 @@ def apply(pp, options = {})
 end
 
 # Run it twice and test for idempotency
+# And know value of custom fact during acceptance tests
 def apply2(pp)
   it 'works with no error' do
     apply_manifest(pp, catch_failures: true)
   end
+  it 'gets custom fact on first run' do
+    on(hosts, 'facter --json jenkins_plugins')
+  end
   it 'works idempotently' do
     apply_manifest(pp, catch_changes: true)
+  end
+  it 'gets custom fact on second run' do
+    on(hosts, 'facter --json jenkins_plugins')
   end
 end
 


### PR DESCRIPTION

#### Pull Request (PR) description
This module is flapping (acceptance tests can pass or fail).

The second time this manifest is applyed 
```
class {'jenkins':
   cli_remoting_free => true,
   cli               => true,
}
```

the first action done is this `exec`:
https://github.com/voxpupuli/puppet-jenkins/blob/master/manifests/plugin.pp#L181

This exec without condition looks guilty. But it is probably due to content of custom fact `jenkins_plugins`

The goal of the PR is to permit to know the value of the custom fact and permit a check to know if value is as expect.

Edit :
For the moment i only saw an empty custom fact.


