### PR TITLE
Use variables for tries and try_sleep everywhere instead of hardcoding

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -26,6 +26,8 @@ class jenkins::cli {
   $extract_jar = "jar -xf ${jenkins::libdir}/jenkins.war WEB-INF/jenkins-cli.jar"
   $move_jar = "mv WEB-INF/jenkins-cli.jar ${jar}"
   $remove_dir = 'rm -rf WEB-INF'
+  $cli_tries = $::jenkins::cli_tries
+  $cli_try_sleep = $::jenkins::cli_try_sleep
 
   # make sure we always call Exec[jenlins-cli] in case
   # the binary does not exist
@@ -66,8 +68,8 @@ class jenkins::cli {
   exec { 'safe-restart-jenkins':
     command     => "${cmd} safe-restart && /bin/sleep 10",
     path        => ['/bin', '/usr/bin'],
-    tries       => 10,
-    try_sleep   => 2,
+    tries       => $cli_tries,
+    try_sleep   => $cli_try_sleep,
     refreshonly => true,
     require     => File[$jar],
   }

--- a/manifests/cli/config.pp
+++ b/manifests/cli/config.pp
@@ -60,7 +60,7 @@ class jenkins::cli::config(
     }
   }
 
-  # We manage the password file, to avoid printing username/password in the 
+  # We manage the password file, to avoid printing username/password in the
   # ps ax output.
   # If file exists, we assume the user manages permissions and content
   if $cli_username and $cli_password and !$cli_password_file_exists {

--- a/manifests/cli/reload.pp
+++ b/manifests/cli/reload.pp
@@ -5,14 +5,16 @@
 class jenkins::cli::reload {
   assert_private()
 
+  $cli_tries = $::jenkins::cli_tries
+  $cli_try_sleep = $::jenkins::cli_try_sleep
   $jar_file = $jenkins::cli::jar
 
   # Reload all Jenkins config from disk (only when notified)
   exec { 'reload-jenkins':
     command     => "${::jenkins::cli::cmd} reload-configuration",
     path        => ['/bin', '/usr/bin'],
-    tries       => 10,
-    try_sleep   => 2,
+    tries       => $cli_tries,
+    try_sleep   => $cli_try_sleep,
     refreshonly => true,
     require     => File[$jar_file],
   }


### PR DESCRIPTION
#### Pull Request (PR) description
We sometimes run into issues where the fixed "tries 10, try_sleep: 2" on the safe-restart-jenkins isn't enough, which causes the puppetrun to fail.

We would like to be able to configure it more. There's already a cli_tries and cli_try_sleep available that fits our use case, so I reused that one.
