### PR TITLE
Workaround for windows fact errors; empty plugins fact returns nil

### DIFF
--- a/lib/facter/jenkins.rb
+++ b/lib/facter/jenkins.rb
@@ -4,7 +4,14 @@
 # jenkins plugins + versions.
 #
 #
+#require 'puppet/jenkins/facts'
+require 'facter'
+
+if Facter.value(:kernel) == 'windows'
+require File.join(File.dirname(__FILE__), '..', 'puppet/jenkins/facts.rb')
+else
 require 'puppet/jenkins/facts'
+end
 
 # If we're being loaded inside the module, we'll need to go ahead and add our
 # facts then won't we?

--- a/lib/puppet/jenkins/facts.rb
+++ b/lib/puppet/jenkins/facts.rb
@@ -33,7 +33,7 @@ module Puppet
           manifest = plugins[plugin]
           buffer << "#{plugin} #{manifest[:plugin_version]}"
         end
-        buffer.join(', ')
+        buffer.join(', ') unless buffer.length == 0
       end
     end
   end


### PR DESCRIPTION
Fix Windows fact error:
ERROR puppetlabs.facter - error while resolving custom facts in C:/ProgramData\PuppetLabs\puppet\cache\lib\facter\jenkins.rb: cannot load such file -- puppet/jenkins/facts

Remove empty fact jenkins_plugins for nodes not running Jenkins server