### PR TITLE
Fix issue with detached plugins taking priority.

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -99,7 +99,7 @@ define jenkins::plugin(
   }
 
   $plugin_ext = regsubst($download_url, '^.*\.(hpi|jpi)$', '\1')
-  $plugin     = "${name}.${plugin_ext}"
+  $plugin     = "${name}.jpi"
   # sanity check extension
   if ! $plugin_ext {
     fail("unsupported plugin extension in source url: ${download_url}")
@@ -121,29 +121,6 @@ define jenkins::plugin(
       false   => present,
       default => absent,
     }
-
-    # at least as of jenkins 1.651, if the version of a plugin being downloaded
-    # has a .hpi extension, and there is an existing version of the plugin
-    # present with a .jpi extension, jenkins will actually delete the .hpi
-    # version when restarted. Essentially making it impossible to
-    # (up|down)grade a plugin from .jpi -> .hpi via puppet across extension
-    # changes.  Regardless, we should be relying on jenkins to guess which
-    # plugin archive to use and cleanup any conflicting extensions.
-    $inverse_plugin_ext = $plugin_ext ? {
-      'hpi'   => 'jpi',
-      'jpi'   => 'hpi',
-    }
-    $inverse_plugin     = "${name}.${inverse_plugin_ext}"
-
-    file {[
-      "${::jenkins::plugin_dir}/${inverse_plugin}",
-      "${::jenkins::plugin_dir}/${inverse_plugin}.disabled",
-      "${::jenkins::plugin_dir}/${inverse_plugin}.pinned",
-    ]:
-      ensure => absent,
-      before => Archive[$plugin],
-    }
-
 
     # Allow plugins that are already installed to be enabled/disabled.
     file { "${::jenkins::plugin_dir}/${plugin}.disabled":

--- a/spec/acceptance/plugin_spec.rb
+++ b/spec/acceptance/plugin_spec.rb
@@ -20,7 +20,7 @@ describe 'jenkins class', order: :defined do
   ]
 
   shared_examples 'has_git_plugin' do
-    describe file("#{$pdir}/git.hpi") do
+    describe file("#{$pdir}/git.jpi") do
       it { is_expected.to be_file }
     end
     describe file("#{$pdir}/git") do
@@ -95,7 +95,7 @@ describe 'jenkins class', order: :defined do
           apply(pp, catch_changes: true)
 
           # Find the version of the installed git plugin
-          git_version = shell("unzip -p #{$pdir}/git.hpi META-INF/MANIFEST.MF | sed 's/Plugin-Version: \\\(.*\\\)/\\1/;tx;d;:x'").stdout.strip
+          git_version = shell("unzip -p #{$pdir}/git.jpi META-INF/MANIFEST.MF | sed 's/Plugin-Version: \\\(.*\\\)/\\1/;tx;d;:x'").stdout.strip
           git_version.should eq('1.0')
         end
       it_behaves_like 'has_git_plugin'

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -15,16 +15,16 @@ describe 'jenkins::plugin' do
 
   describe 'without version' do
     it do
-      is_expected.to contain_archive("#{title}.hpi").with(
+      is_expected.to contain_archive("#{title}.jpi").with(
         source: "#{plugin_host}/latest/myplug.hpi",
-        path: "#{pdir}/#{title}.hpi",
+        path: "#{pdir}/#{title}.jpi",
         cleanup: false,
         extract: false
       ).that_requires("File[#{pdir}]").
         that_notifies('Service[jenkins]')
     end
     it do
-      is_expected.to contain_file("#{pdir}/#{title}.hpi").with(
+      is_expected.to contain_file("#{pdir}/#{title}.jpi").with(
         owner: 'jenkins',
         group: 'jenkins',
         mode: '0644'
@@ -36,11 +36,11 @@ describe 'jenkins::plugin' do
     let(:params) { { version: '1.2.3' } }
 
     it do
-      is_expected.to contain_archive('myplug.hpi').with(
+      is_expected.to contain_archive('myplug.jpi').with(
         source: "#{plugin_host}/download/plugins/myplug/1.2.3/myplug.hpi"
       )
     end
-    it { is_expected.to contain_file("#{pdir}/myplug.hpi") }
+    it { is_expected.to contain_file("#{pdir}/myplug.jpi") }
   end
 
   describe 'with version and in middle of jenkins_plugins fact' do
@@ -48,8 +48,8 @@ describe 'jenkins::plugin' do
 
     before { facts[:jenkins_plugins] = 'myplug 1.2.3, fooplug 1.4.5' }
 
-    it { is_expected.not_to contain_archive('myplug.hpi') }
-    it { is_expected.to contain_file("#{pdir}/myplug.hpi") }
+    it { is_expected.not_to contain_archive('myplug.jpi') }
+    it { is_expected.to contain_file("#{pdir}/myplug.jpi") }
   end
 
   describe 'with version and at end of jenkins_plugins fact' do
@@ -57,8 +57,8 @@ describe 'jenkins::plugin' do
 
     before { facts[:jenkins_plugins] = 'fooplug 1.4.5, myplug 1.2.3' }
 
-    it { is_expected.not_to contain_archive('myplug.hpi') }
-    it { is_expected.to contain_file("#{pdir}/myplug.hpi") }
+    it { is_expected.not_to contain_archive('myplug.jpi') }
+    it { is_expected.to contain_file("#{pdir}/myplug.jpi") }
   end
 
   describe 'with name and version' do
@@ -67,8 +67,8 @@ describe 'jenkins::plugin' do
 
       before { facts[:jenkins_plugins] = 'fooplug 1.4.5, bar-myplug 1.2.3' }
 
-      it { is_expected.to contain_archive('myplug.hpi') }
-      it { is_expected.to contain_file('/var/lib/jenkins/plugins/myplug.hpi') }
+      it { is_expected.to contain_archive('myplug.jpi') }
+      it { is_expected.to contain_file('/var/lib/jenkins/plugins/myplug.jpi') }
     end
 
     describe 'where name & version are a substring of another plugin' do
@@ -76,8 +76,8 @@ describe 'jenkins::plugin' do
 
       before { facts[:jenkins_plugins] = 'fooplug 1.4.5, bar-myplug 1.2.3.4' }
 
-      it { is_expected.to contain_archive('myplug.hpi') }
-      it { is_expected.to contain_file('/var/lib/jenkins/plugins/myplug.hpi') }
+      it { is_expected.to contain_archive('myplug.jpi') }
+      it { is_expected.to contain_file('/var/lib/jenkins/plugins/myplug.jpi') }
     end
 
     describe 'where version is a substring of the already installed plugin' do
@@ -85,8 +85,8 @@ describe 'jenkins::plugin' do
 
       before { facts[:jenkins_plugins] = 'fooplug 1.4.5, myplug 1.2.3.4' }
 
-      it { is_expected.to contain_archive('myplug.hpi') }
-      it { is_expected.to contain_file('/var/lib/jenkins/plugins/myplug.hpi') }
+      it { is_expected.to contain_archive('myplug.jpi') }
+      it { is_expected.to contain_file('/var/lib/jenkins/plugins/myplug.jpi') }
     end
 
     describe 'and no plugins are installed (should not actually happen)' do
@@ -94,8 +94,8 @@ describe 'jenkins::plugin' do
 
       before { facts[:jenkins_plugins] = '' }
 
-      it { is_expected.to contain_archive('myplug.hpi') }
-      it { is_expected.to contain_file('/var/lib/jenkins/plugins/myplug.hpi') }
+      it { is_expected.to contain_archive('myplug.jpi') }
+      it { is_expected.to contain_file('/var/lib/jenkins/plugins/myplug.jpi') }
     end
 
     describe 'where version contains a + and is already installed' do
@@ -103,23 +103,23 @@ describe 'jenkins::plugin' do
 
       before { facts[:jenkins_plugins] = 'myplug 1.2+3.4' }
 
-      it { is_expected.not_to contain_archive('myplug.hpi') }
-      it { is_expected.to contain_file('/var/lib/jenkins/plugins/myplug.hpi') }
+      it { is_expected.not_to contain_archive('myplug.jpi') }
+      it { is_expected.to contain_file('/var/lib/jenkins/plugins/myplug.jpi') }
     end
   end # 'with name and version'
 
   describe 'with enabled is false' do
     let(:params) { { enabled: false } }
 
-    it { is_expected.to contain_archive('myplug.hpi') }
-    it { is_expected.to contain_file("#{pdir}/myplug.hpi") }
+    it { is_expected.to contain_archive('myplug.jpi') }
+    it { is_expected.to contain_file("#{pdir}/myplug.jpi") }
     it do
-      is_expected.to contain_file("#{pdir}/myplug.hpi.disabled").with(
+      is_expected.to contain_file("#{pdir}/myplug.jpi.disabled").with(
         ensure: 'present',
         owner: 'jenkins',
         group: 'jenkins',
         mode: '0644'
-      ).that_requires("Archive[#{title}.hpi]").
+      ).that_requires("Archive[#{title}.jpi]").
         that_notifies('Service[jenkins]')
     end
   end
@@ -127,10 +127,10 @@ describe 'jenkins::plugin' do
   describe 'with enabled is true' do
     let(:params) { { enabled: true } }
 
-    it { is_expected.to contain_archive('myplug.hpi') }
-    it { is_expected.to contain_file("#{pdir}/myplug.hpi") }
+    it { is_expected.to contain_archive('myplug.jpi') }
+    it { is_expected.to contain_file("#{pdir}/myplug.jpi") }
     it do
-      is_expected.to contain_file("#{pdir}/myplug.hpi.disabled").with(
+      is_expected.to contain_file("#{pdir}/myplug.jpi.disabled").with(
         ensure: 'absent'
       )
     end
@@ -147,7 +147,7 @@ describe 'jenkins::plugin' do
     end
 
     it do
-      is_expected.to contain_archive('myplug.hpi').with(
+      is_expected.to contain_archive('myplug.jpi').with(
         proxy_server: 'http://proxy.company.com:8080'
       )
     end
@@ -163,7 +163,7 @@ describe 'jenkins::plugin' do
     end
 
     it do
-      is_expected.to contain_archive('myplug.hpi').with(
+      is_expected.to contain_archive('myplug.jpi').with(
         source: 'https://update.jenkins.custom/latest/myplug.hpi'
       )
     end
@@ -172,7 +172,7 @@ describe 'jenkins::plugin' do
   describe 'with a custom update center' do
     shared_examples 'execute the right fetch command' do
       it 'retrieves the plugin' do
-        expect(subject).to contain_archive('git.hpi').with(source: expected_url.to_s)
+        expect(subject).to contain_archive('git.jpi').with(source: expected_url.to_s)
       end
     end
 
@@ -225,7 +225,7 @@ describe 'jenkins::plugin' do
   describe 'source' do
     shared_examples 'should download from $source url' do
       it 'downloads from $source url' do
-        is_expected.to contain_archive('myplug.hpi').with(
+        is_expected.to contain_archive('myplug.jpi').with(
           source: 'http://e.org/myplug.hpi'
         ).
           that_requires("File[#{pdir}]")
@@ -273,22 +273,22 @@ describe 'jenkins::plugin' do
         let(:params) { { pin: true } }
 
         it do
-          is_expected.to contain_file("#{pdir}/foo.hpi.pinned").with(
+          is_expected.to contain_file("#{pdir}/foo.jpi.pinned").with(
             ensure: 'file',
             owner: 'jenkins',
             group: 'jenkins'
           ).
-            that_requires('Archive[foo.hpi]').
+            that_requires('Archive[foo.jpi]').
             that_notifies('Service[jenkins]')
         end
       end
       context 'with pin => false' do
         let(:params) { { pin: false } }
 
-        it { is_expected.to contain_file("#{pdir}/foo.hpi.pinned").without_ensure }
+        it { is_expected.to contain_file("#{pdir}/foo.jpi.pinned").without_ensure }
       end
       context 'with default pin param' do
-        it { is_expected.to contain_file("#{pdir}/foo.hpi.pinned").without_ensure }
+        it { is_expected.to contain_file("#{pdir}/foo.jpi.pinned").without_ensure }
       end
     end
   end # pinned file extension name


### PR DESCRIPTION
As of Jenkins 2.176.2 detached plugins were taking precedence over specified plugins due to a fix that was introduced for docker: https://issues.jenkins-ci.org/browse/JENKINS-57528.

The fix in Jenkins ensured stricter processing of plugins. the module was installing plugins as `.hpi` files where Jenkins expects them to be `.jpi` files. 

This problem was highlighted in https://github.com/voxpupuli/puppet-jenkins/issues/926.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
