### PR TITLE
Update references to rtyler/jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ and ssh key file, SSH authentication is preferred.
 
 ## Getting Started
 ```bash
-puppet module install rtyler/jenkins
+puppet module install puppet/jenkins
 ```
 
 ```puppet
@@ -399,7 +399,7 @@ If you use [librarian-puppet](https://github.com/rodjek/librarian-puppet), add
 the following to your `Puppetfile`:
 
 ```ruby
-mod "rtyler/jenkins"
+mod "puppet/jenkins"
 ```
 
 ### With the "puppet module" tool
@@ -410,7 +410,7 @@ allowing you to easily install the released version of the module
 
 To quickly try this module with the puppet module tool:
 
-    % sudo puppet module install rtyler/jenkins
+    % sudo puppet module install puppet/jenkins
     % sudo puppet apply -v -e 'include jenkins'
     info: Loading facts in facter_dot_d
     info: Loading facts in facter_dot_d


### PR DESCRIPTION
#### Pull Request (PR) description

Updates module name references from `rtyler/jenkins` to `puppet/jenkins` in the README.

#### This Pull Request (PR) fixes the following issues

Fixes #934