### PR TITLE
Removes quotes from $JAVA_ARGS, otherwise java fails to start

### DIFF
--- a/templates/jenkins-slave-run.erb
+++ b/templates/jenkins-slave-run.erb
@@ -14,7 +14,7 @@ fail() {
 SLAVE_ARGS=()
 
 [[ -n "$JAVA_ARGS" ]] &&
-  SLAVE_ARGS+=("$JAVA_ARGS")
+  SLAVE_ARGS+=($JAVA_ARGS)
 
 SLAVE_ARGS+=(-jar "$JENKINS_SLAVE_JAR")
 


### PR DESCRIPTION
Solves #939