### PR TITLE
Remove redundant code

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -453,12 +453,8 @@ class jenkins(
     }
   }
 
-  if defined('::firewall') {
-    if $configure_firewall == undef {
-      fail('The firewall module is included in your manifests, please configure $configure_firewall in the jenkins module')
-    } elsif $configure_firewall {
-      include jenkins::firewall
-    }
+  if defined('::firewall') and $configure_firewall {
+    include jenkins::firewall
   }
 
   if $cli {

--- a/spec/classes/jenkins_spec.rb
+++ b/spec/classes/jenkins_spec.rb
@@ -72,12 +72,6 @@ describe 'jenkins', type: :class do
       it { is_expected.not_to contain_class 'jenkins::firewall' }
     end
 
-    describe 'with firewall, configure_firewall unset' do
-      let(:pre_condition) { 'define firewall ($action, $state, $dport, $proto) {}' }
-
-      it { expect { is_expected.to raise_error(Puppet::Error) } }
-    end
-
     describe 'sysconfdir =>' do
       context '/foo/bar' do
         let(:params) { { sysconfdir: '/foo/bar' } }


### PR DESCRIPTION
532242964375efc1013ba186f201ecbd74de0b36 changed the default from undef to false which means this code could never be hit again. Because the actual check was incorrect the tests never showed this.