### PR TITLE
Fix a reference to jenkins::service

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -217,7 +217,7 @@ define jenkins::plugin(
       owner   => $jenkins::user,
       group   => $jenkins::group,
       mode    => '0644',
-      notify  => Class['::jenkins::service'],
+      notify  => $notify,
     }
   }
 }


### PR DESCRIPTION
If $mananage_service => false, then the jenkins::service class doesn't exist. In 65363b69b54e1aa37e5821b0e94357de3af9c4f0 this was fixed via $notify, but one instance was missed.