### PR TITLE
Prefer JPI plugins over HPI

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -94,7 +94,7 @@ define jenkins::plugin(
 
   # if $source is specified, it overrides any other URL construction
   $download_url = $source ? {
-    undef   => "${base_url}${name}.hpi",
+    undef   => "${base_url}${name}.jpi",
     default => $source,
   }
 

--- a/spec/acceptance/plugin_spec.rb
+++ b/spec/acceptance/plugin_spec.rb
@@ -19,7 +19,7 @@ describe 'jenkins class', order: :defined do
   ].freeze
 
   shared_examples 'has_git_plugin' do
-    describe file("#{PDIR}/git.hpi") do
+    describe file("#{PDIR}/git.jpi") do
       it { is_expected.to be_file }
     end
     describe file("#{PDIR}/git") do
@@ -94,7 +94,7 @@ describe 'jenkins class', order: :defined do
           apply(pp, catch_changes: true)
 
           # Find the version of the installed git plugin
-          git_version = shell("unzip -p #{PDIR}/git.hpi META-INF/MANIFEST.MF | sed 's/Plugin-Version: \\\(.*\\\)/\\1/;tx;d;:x'").stdout.strip
+          git_version = shell("unzip -p #{PDIR}/git.jpi META-INF/MANIFEST.MF | sed 's/Plugin-Version: \\\(.*\\\)/\\1/;tx;d;:x'").stdout.strip
           git_version.should eq('1.0')
         end
       it_behaves_like 'has_git_plugin'

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -11,16 +11,16 @@ describe 'jenkins::plugin' do
 
       describe 'without version' do
         it do
-          is_expected.to contain_archive("#{title}.hpi").with(
-            source: "#{plugin_host}/latest/myplug.hpi",
-            path: "#{pdir}/#{title}.hpi",
+          is_expected.to contain_archive("#{title}.jpi").with(
+            source: "#{plugin_host}/latest/myplug.jpi",
+            path: "#{pdir}/#{title}.jpi",
             cleanup: false,
             extract: false
           ).that_requires("File[#{pdir}]").
             that_notifies('Service[jenkins]')
         end
         it do
-          is_expected.to contain_file("#{pdir}/#{title}.hpi").with(
+          is_expected.to contain_file("#{pdir}/#{title}.jpi").with(
             owner: 'jenkins',
             group: 'jenkins',
             mode: '0644'
@@ -32,11 +32,11 @@ describe 'jenkins::plugin' do
         let(:params) { { version: '1.2.3' } }
 
         it do
-          is_expected.to contain_archive('myplug.hpi').with(
-            source: "#{plugin_host}/download/plugins/myplug/1.2.3/myplug.hpi"
+          is_expected.to contain_archive('myplug.jpi').with(
+            source: "#{plugin_host}/download/plugins/myplug/1.2.3/myplug.jpi"
           )
         end
-        it { is_expected.to contain_file("#{pdir}/myplug.hpi") }
+        it { is_expected.to contain_file("#{pdir}/myplug.jpi") }
       end
 
       describe 'with version and in middle of jenkins_plugins fact' do
@@ -44,8 +44,8 @@ describe 'jenkins::plugin' do
 
         let(:facts) { super().merge(jenkins_plugins: 'myplug 1.2.3, fooplug 1.4.5') }
 
-        it { is_expected.not_to contain_archive('myplug.hpi') }
-        it { is_expected.to contain_file("#{pdir}/myplug.hpi") }
+        it { is_expected.not_to contain_archive('myplug.jpi') }
+        it { is_expected.to contain_file("#{pdir}/myplug.jpi") }
       end
 
       describe 'with version and at end of jenkins_plugins fact' do
@@ -53,8 +53,8 @@ describe 'jenkins::plugin' do
 
         let(:facts) { super().merge(jenkins_plugins: 'fooplug 1.4.5, myplug 1.2.3') }
 
-        it { is_expected.not_to contain_archive('myplug.hpi') }
-        it { is_expected.to contain_file("#{pdir}/myplug.hpi") }
+        it { is_expected.not_to contain_archive('myplug.jpi') }
+        it { is_expected.to contain_file("#{pdir}/myplug.jpi") }
       end
 
       describe 'with name and version' do
@@ -63,8 +63,8 @@ describe 'jenkins::plugin' do
 
           let(:facts) { super().merge(jenkins_plugins: 'fooplug 1.4.5, bar-myplug 1.2.3') }
 
-          it { is_expected.to contain_archive('myplug.hpi') }
-          it { is_expected.to contain_file('/var/lib/jenkins/plugins/myplug.hpi') }
+          it { is_expected.to contain_archive('myplug.jpi') }
+          it { is_expected.to contain_file('/var/lib/jenkins/plugins/myplug.jpi') }
         end
 
         describe 'where name & version are a substring of another plugin' do
@@ -72,8 +72,8 @@ describe 'jenkins::plugin' do
 
           let(:facts) { super().merge(jenkins_plugins: 'fooplug 1.4.5, bar-myplug 1.2.3.4') }
 
-          it { is_expected.to contain_archive('myplug.hpi') }
-          it { is_expected.to contain_file('/var/lib/jenkins/plugins/myplug.hpi') }
+          it { is_expected.to contain_archive('myplug.jpi') }
+          it { is_expected.to contain_file('/var/lib/jenkins/plugins/myplug.jpi') }
         end
 
         describe 'where version is a substring of the already installed plugin' do
@@ -81,8 +81,8 @@ describe 'jenkins::plugin' do
 
           let(:facts) { super().merge(jenkins_plugins: 'fooplug 1.4.5, myplug 1.2.3.4') }
 
-          it { is_expected.to contain_archive('myplug.hpi') }
-          it { is_expected.to contain_file('/var/lib/jenkins/plugins/myplug.hpi') }
+          it { is_expected.to contain_archive('myplug.jpi') }
+          it { is_expected.to contain_file('/var/lib/jenkins/plugins/myplug.jpi') }
         end
 
         describe 'and no plugins are installed (should not actually happen)' do
@@ -90,8 +90,8 @@ describe 'jenkins::plugin' do
 
           let(:facts) { super().merge(jenkins_plugins: '') }
 
-          it { is_expected.to contain_archive('myplug.hpi') }
-          it { is_expected.to contain_file('/var/lib/jenkins/plugins/myplug.hpi') }
+          it { is_expected.to contain_archive('myplug.jpi') }
+          it { is_expected.to contain_file('/var/lib/jenkins/plugins/myplug.jpi') }
         end
 
         describe 'where version contains a + and is already installed' do
@@ -99,23 +99,23 @@ describe 'jenkins::plugin' do
 
           let(:facts) { super().merge(jenkins_plugins: 'myplug 1.2+3.4') }
 
-          it { is_expected.not_to contain_archive('myplug.hpi') }
-          it { is_expected.to contain_file('/var/lib/jenkins/plugins/myplug.hpi') }
+          it { is_expected.not_to contain_archive('myplug.jpi') }
+          it { is_expected.to contain_file('/var/lib/jenkins/plugins/myplug.jpi') }
         end
       end # 'with name and version'
 
       describe 'with enabled is false' do
         let(:params) { { enabled: false } }
 
-        it { is_expected.to contain_archive('myplug.hpi') }
-        it { is_expected.to contain_file("#{pdir}/myplug.hpi") }
+        it { is_expected.to contain_archive('myplug.jpi') }
+        it { is_expected.to contain_file("#{pdir}/myplug.jpi") }
         it do
-          is_expected.to contain_file("#{pdir}/myplug.hpi.disabled").with(
+          is_expected.to contain_file("#{pdir}/myplug.jpi.disabled").with(
             ensure: 'present',
             owner: 'jenkins',
             group: 'jenkins',
             mode: '0644'
-          ).that_requires("Archive[#{title}.hpi]").
+          ).that_requires("Archive[#{title}.jpi]").
             that_notifies('Service[jenkins]')
         end
       end
@@ -123,10 +123,10 @@ describe 'jenkins::plugin' do
       describe 'with enabled is true' do
         let(:params) { { enabled: true } }
 
-        it { is_expected.to contain_archive('myplug.hpi') }
-        it { is_expected.to contain_file("#{pdir}/myplug.hpi") }
+        it { is_expected.to contain_archive('myplug.jpi') }
+        it { is_expected.to contain_file("#{pdir}/myplug.jpi") }
         it do
-          is_expected.to contain_file("#{pdir}/myplug.hpi.disabled").with(
+          is_expected.to contain_file("#{pdir}/myplug.jpi.disabled").with(
             ensure: 'absent'
           )
         end
@@ -143,7 +143,7 @@ describe 'jenkins::plugin' do
         end
 
         it do
-          is_expected.to contain_archive('myplug.hpi').with(
+          is_expected.to contain_archive('myplug.jpi').with(
             proxy_server: 'http://proxy.company.com:8080'
           )
         end
@@ -159,8 +159,8 @@ describe 'jenkins::plugin' do
         end
 
         it do
-          is_expected.to contain_archive('myplug.hpi').with(
-            source: 'https://update.jenkins.custom/latest/myplug.hpi'
+          is_expected.to contain_archive('myplug.jpi').with(
+            source: 'https://update.jenkins.custom/latest/myplug.jpi'
           )
         end
       end
@@ -168,7 +168,7 @@ describe 'jenkins::plugin' do
       describe 'with a custom update center' do
         shared_examples 'execute the right fetch command' do
           it 'retrieves the plugin' do
-            is_expected.to contain_archive('git.hpi').with(source: expected_url.to_s)
+            is_expected.to contain_archive('git.jpi').with(source: expected_url.to_s)
           end
         end
 
@@ -179,7 +179,7 @@ describe 'jenkins::plugin' do
             let(:version) { '1.3.3.7' }
             let(:params) { { version: version } }
             let(:expected_url) do
-              "#{plugin_host}/download/plugins/#{title}/#{version}/#{title}.hpi"
+              "#{plugin_host}/download/plugins/#{title}/#{version}/#{title}.jpi"
             end
 
             include_examples 'execute the right fetch command'
@@ -187,7 +187,7 @@ describe 'jenkins::plugin' do
 
           context 'without a version' do
             let(:expected_url) do
-              "#{plugin_host}/latest/#{title}.hpi"
+              "#{plugin_host}/latest/#{title}.jpi"
             end
 
             include_examples 'execute the right fetch command'
@@ -195,12 +195,12 @@ describe 'jenkins::plugin' do
         end
 
         context 'with a custom update_url' do
-          let(:update_url) { 'http://rspec' }
+          let(:update_url) { 'http://rspec.example.com' }
 
           context 'without a version' do
             let(:params) { { update_url: update_url } }
             let(:expected_url) do
-              "#{update_url}/latest/#{title}.hpi"
+              "#{update_url}/latest/#{title}.jpi"
             end
 
             include_examples 'execute the right fetch command'
@@ -210,7 +210,7 @@ describe 'jenkins::plugin' do
             let(:version) { '1.2.3' }
             let(:params) { { update_url: update_url, version: version } }
             let(:expected_url) do
-              "#{update_url}/download/plugins/#{title}/#{version}/#{title}.hpi"
+              "#{update_url}/download/plugins/#{title}/#{version}/#{title}.jpi"
             end
 
             include_examples 'execute the right fetch command'
@@ -221,14 +221,14 @@ describe 'jenkins::plugin' do
       describe 'source' do
         shared_examples 'should download from $source url' do
           it 'downloads from $source url' do
-            is_expected.to contain_archive('myplug.hpi').with(
-              source: 'http://e.org/myplug.hpi'
+            is_expected.to contain_archive('myplug.jpi').with(
+              source: 'http://e.org/myplug.jpi'
             ).
               that_requires("File[#{pdir}]")
           end
         end
 
-        let(:params) { { source: 'http://e.org/myplug.hpi' } }
+        let(:params) { { source: 'http://e.org/myplug.jpi' } }
 
         context 'other params at defaults' do
           include_examples 'should download from $source url'
@@ -248,7 +248,7 @@ describe 'jenkins::plugin' do
 
         context 'validate_string' do
           context 'string' do
-            let(:params) { { source: 'foo.hpi' } }
+            let(:params) { { source: 'foo.jpi' } }
 
             it { is_expected.to compile.and_raise_error(%r{source}) }
           end
@@ -269,22 +269,22 @@ describe 'jenkins::plugin' do
             let(:params) { { pin: true } }
 
             it do
-              is_expected.to contain_file("#{pdir}/foo.hpi.pinned").with(
+              is_expected.to contain_file("#{pdir}/foo.jpi.pinned").with(
                 ensure: 'file',
                 owner: 'jenkins',
                 group: 'jenkins'
               ).
-                that_requires('Archive[foo.hpi]').
+                that_requires('Archive[foo.jpi]').
                 that_notifies('Service[jenkins]')
             end
           end
           context 'with pin => false' do
             let(:params) { { pin: false } }
 
-            it { is_expected.to contain_file("#{pdir}/foo.hpi.pinned").without_ensure }
+            it { is_expected.to contain_file("#{pdir}/foo.jpi.pinned").without_ensure }
           end
           context 'with default pin param' do
-            it { is_expected.to contain_file("#{pdir}/foo.hpi.pinned").without_ensure }
+            it { is_expected.to contain_file("#{pdir}/foo.jpi.pinned").without_ensure }
           end
         end
       end # pinned file extension name


### PR DESCRIPTION
As of Jenkins 2.176.2 detached plugins are taking precedence over specified plugins due to a fix that was introduced for docker: https://issues.jenkins-ci.org/browse/JENKINS-57528.

The fix in Jenkins ensured stricter processing of plugins. The module was installing plugins as .hpi files where Jenkins expects them to be .jpi files.

#### This Pull Request (PR) fixes the following issues

It is based on the implementation in #929 which was aimed at addressing #926.

Fixes #926
Fixes #929