### PR TITLE
Allow disabling automatic Jenkins master restarts

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,9 @@
 #   * ``running`` (default)
 #   * ``stopped``
 #
+# @param service_restart
+#   Whether to restart the service on config_hash and plugins
+#
 # @param service_provider
 #   Override ``Service[jenkins]`` resource provider
 #
@@ -301,6 +304,7 @@ class jenkins(
   Boolean $manage_service                         = true,
   Boolean $service_enable                         = $jenkins::params::service_enable,
   Enum['running', 'stopped'] $service_ensure      = $jenkins::params::service_ensure,
+  Boolean $service_restart                        = $jenkins::params::service_restart,
   Optional[String] $service_provider              = $jenkins::params::service_provider,
   Hash $config_hash                               = {},
   Hash $plugin_hash                               = {},

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class jenkins::params {
   $direct_download       = undef
   $service_enable        = true
   $service_ensure        = 'running'
+  $service_restart       = true
   $install_java          = true
   $swarm_version         = '2.2'
   $default_plugins_host  = 'https://updates.jenkins.io'

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -37,7 +37,7 @@ define jenkins::plugin(
 
   include jenkins
 
-  if $jenkins::manage_service {
+  if $jenkins::manage_service and $jenkins::service_restart {
     $notify = Class['jenkins::service']
   } else {
     $notify = undef

--- a/manifests/sysconfig.pp
+++ b/manifests/sysconfig.pp
@@ -8,7 +8,7 @@ define jenkins::sysconfig(
     warning("Jenkins::Sysconfig[${name}]: detected \'\$\' in value -- be advised the variable interpolation will not work under systemd")
   }
 
-  if $jenkins::manage_service {
+  if $jenkins::manage_service and $jenkins::service_restart {
     $notify = Class['::jenkins::service']
   } else {
     $notify = undef


### PR DESCRIPTION
This is useful on production Jenkins masters where non-scheduled restarts are
dangerous. Unit file changes and user changes that happen before tha package is
installed are not affected.