### PR TITLE
change 'require' to 'require_relative'

### DIFF
--- a/lib/facter/jenkins.rb
+++ b/lib/facter/jenkins.rb
@@ -4,7 +4,7 @@
 # jenkins plugins + versions.
 #
 #
-require 'puppet/jenkins/facts'
+require_relative '../puppet/jenkins/facts'
 
 # If we're being loaded inside the module, we'll need to go ahead and add our
 # facts then won't we?


### PR DESCRIPTION
on 2019.2 PE, facter is throwing an error on Windows nodes -> "error while resolving custom facts in C:/ProgramData\PuppetLabs\puppet\cache\lib\facter\jenkins.rb: cannot load such file -- puppet/jenkins/facts

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
