### PR TITLE
Remove duplicate resources in acceptance tests

### DIFF
--- a/spec/acceptance/xtypes/jenkins_credentials_spec.rb
+++ b/spec/acceptance/xtypes/jenkins_credentials_spec.rb
@@ -238,8 +238,6 @@ describe 'jenkins_credentials' do
           pp = base_manifest + <<-EOS
             jenkins::plugin { [
               'google-oauth-plugin',
-              'credentials',
-              'structs',
               'oauth-credentials',
             ]: }
 
@@ -277,8 +275,6 @@ describe 'jenkins_credentials' do
           pp = base_manifest + <<-EOS
             jenkins::plugin { [
               'google-oauth-plugin',
-              'credentials',
-              'structs',
               'oauth-credentials',
             ]: }
 


### PR DESCRIPTION
These plugins are also in the default plugins so don't need to be defined again.