### PR TITLE
Feature/cli auth fix

### DIFF
--- a/lib/puppet/x/jenkins/provider/cli.rb
+++ b/lib/puppet/x/jenkins/provider/cli.rb
@@ -271,7 +271,8 @@ class Puppet::X::Jenkins::Provider::Cli < Puppet::Provider
     cli_auth_errors = [
       'You must authenticate to access this Jenkins.',
       'anonymous is missing the Overall/Read permission',
-      'anonymous is missing the Overall/RunScripts permission'
+      'anonymous is missing the Overall/RunScripts permission',
+      'anonymous is missing the Overall/Administer permission'
     ]
     # network errors / jenkins not ready for connections not related to
     # authenication failures

--- a/spec/unit/puppet/x/jenkins/provider/cli_spec.rb
+++ b/spec/unit/puppet/x/jenkins/provider/cli_spec.rb
@@ -11,13 +11,15 @@ describe Puppet::X::Jenkins::Provider::Cli do
   NetError = Puppet::X::Jenkins::Provider::Cli::NetError
   UnknownError = Puppet::X::Jenkins::Provider::Cli::UnknownError
 
-  CLI_AUTH_ERRORS = [<<-EOS, <<-EOS, <<-EOS].freeze
+  CLI_AUTH_ERRORS = [<<-EOS, <<-EOS, <<-EOS, <<-EOS].freeze
     anonymous is missing the Overall/Read permission
   EOS
     You must authenticate to access this Jenkins.
     Use --username/--password/--password-file parameters or login command.
   EOS
     anonymous is missing the Overall/RunScripts permission
+  EOS
+    anonymous is missing the Overall/Administer permission
   EOS
 
   CLI_NET_ERRORS = [<<-EOS, <<-EOS].freeze


### PR DESCRIPTION
since jenkins 2.222.1 LTS some new security features are on by default, which causes the "anonymous is missing the Overall/Administer permission" error when trying cli commands as anonymous.
This PR adds it to the cli_auth_errors list to allow retry with auth.
