### PR TITLE
Use eval in jenkins-run

### DIFF
--- a/templates/jenkins-run.erb
+++ b/templates/jenkins-run.erb
@@ -75,4 +75,4 @@ if [ "$JENKINS_ENABLE_ACCESS_LOG" = "yes" ]; then
   PARAMS+=("--simpleAccessLogger.file=/var/log/jenkins/access_log")
 fi
 
-$JAVA_CMD "${PARAMS[@]}"
+eval "$JAVA_CMD ${PARAMS[@]}"


### PR DESCRIPTION
It's required to support escaping spaces in JENKINS_JAVA_CMD, JENKINS_JAVA_OPTIONS, JENKINS_HOME and JENKINS_WAR variables.

For example, it's impossible to set [`hudson.model.DirectoryBrowserSupport.CSP`](https://wiki.jenkins.io/display/JENKINS/Configuring+Content+Security+Policy) without this, since CSP policy has to contain spaces, and escaping spaces wasn't possible in `JENKINS_JAVA_OPTS`.