### PR TITLE
Fix code ordering on 18.04 and add new debian gpg key

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -1,7 +1,7 @@
 # Class: jenkins::repo::debian
 #
 class jenkins::repo::debian (
-  String $gpg_key_id = '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+  String $gpg_key_id = '62A9756BFD780C377CF24BA8FCEF32E745F2C3D5',
 ) {
   assert_private()
 

--- a/manifests/systemd.pp
+++ b/manifests/systemd.pp
@@ -18,10 +18,13 @@ define jenkins::systemd(
     content => template("${module_name}/${service}-run.erb"),
     owner   => $user,
     mode    => '0700',
-    notify  => Service[$service],
   }
 
-  transition { "stop ${service} service":
+  -> systemd::unit_file { "${service}.service":
+    content => template("${module_name}/${service}.service.erb"),
+  }
+
+  -> transition { "stop ${service} service":
     resource   => Service[$service],
     attributes => {
       # lint:ignore:ensure_first_param
@@ -44,9 +47,4 @@ define jenkins::systemd(
     selinux_ignore_defaults => true,
   }
 
-  systemd::unit_file { "${service}.service":
-    content => template("${module_name}/${service}.service.erb"),
-    notify  => Service[$service],
-    require => File[$sysv_init],
-  }
 }


### PR DESCRIPTION
Change code ordering to work with Ubuntu 18.04 and add new upstream gpg key from Jenkins

Fixes 

#920 
#971 