### PR TITLE
Drop code old CLI remoting support

### DIFF
--- a/NATIVE_TYPES_AND_PROVIDERS.md
+++ b/NATIVE_TYPES_AND_PROVIDERS.md
@@ -40,7 +40,6 @@ setup.  The parameters used to override default values are:
 * `cli_password`
 * `cli_password_file`
 * `cli_password_file_exists`
-* `cli_remoting_free`
 
 An example for a secured jenkins (e.g. ad connected) for LTS version
 newer then 2.46.2 (e.g. 2.60.1)
@@ -49,7 +48,6 @@ newer then 2.46.2 (e.g. 2.60.1)
 class { 'jenkins::cli::config':
   cli_username      => 'puppet',
   cli_password_file => 'thisisanactivedirectorypassword',
-  cli_remoting_free => true,
   cli_tries         => 3,
   cli_try_sleep     => 1,
 }
@@ -64,7 +62,6 @@ Note: The file /root/password_file_for_puppet with content
 class { 'jenkins::cli::config':
   cli_username             => 'puppet',
   cli_password_file        => '/root/password_file_for_puppet',
-  cli_remoting_free        => true,
   cli_password_file_exists => true,
   cli_tries                => 3,
   cli_try_sleep            => 1,

--- a/README.md
+++ b/README.md
@@ -29,43 +29,19 @@ See [NATIVE_TYPES_AND_PROVIDERS.md](NATIVE_TYPES_AND_PROVIDERS.md)
 
 # Jenkins 2.54 and 2.46.2 remoting free CLI and username / password CLI auth
 
-## Remoting Free CLI
-
 Jenkins refactored the CLI in 2.54 and 2.46.2 in response to several security
-incidents (See [JENKINS-41745](https://issues.jenkins-ci.org/browse/JENKINS-41745). This module has been adjusted to support the new CLI. However you
-need to tell the module if the new remoting free cli is in place. Please set
-```$::jenkins::cli_remoting_free``` to true for latest Jenkins servers.
+incidents (See [JENKINS-41745](https://issues.jenkins-ci.org/browse/JENKINS-41745).
+This module has been adjusted to support the new CLI.
 
-Note: This is not the default to support backward compatibility. This may become
-a default once this module is released in a new version.
+The CLI supports proper authentication with username and password. It's a
+requirement for supporting AD and OpenID authentications (there is no ssh key
+there). You can supply ```$::jenkins::cli_username``` and
+```$::jenkins::cli_password``` to use username / password based authentication.
+Then the puppet automation user can also reside in A.D
 
-Also note that the module tries to do heuristics for this setting if not specified.
-You can always set this parameter to enforce usage of old or new CLI interface.
-
-Heuristics:
-
-  * LTS:
-    * If manage_repo and repo == lts and version = latest -> true
-    * If manage_repo and repo == lts and version >= 2.46.2 -> true
-    * else false
-  * Non-LTS:
-    * If manage_repo and repo != lts and version = latest -> true
-    * If manage_repo and repo != lts and version >= 2.54 -> true
-    * else false
-
-## Username and Password Auth
-
-The new CLI also supports proper authentication with username and password. This
-has not been supported in this module for a long time, but is a requirement for
-supporting AD and OpenID authentications (there is no ssh key there). You can now
-also supply ```$::jenkins::cli_username``` and ```$::jenkins::cli_password``` to
-use username / password based authentication. Then the puppet automation user can
-also reside in A.D
-
-Note: latest jenkins (2.54++ and 2.46.2++) require a ssh username, so you must also
-provide ```$::jenkins::cli_username``` for ssh. If you specify both username/password
+Note: Jenkins requires a ssh username, so you must also provide
+```$::jenkins::cli_username``` for ssh. If you specify both username/password
 and ssh key file, SSH authentication is preferred.
-
 
 # Using puppet-jenkins
 

--- a/lib/puppet/x/jenkins/config.rb
+++ b/lib/puppet/x/jenkins/config.rb
@@ -20,8 +20,7 @@ class Puppet::X::Jenkins::Config
     cli_username: nil,
     cli_password: nil,
     cli_password_file: '/tmp/jenkins_credentials_for_puppet',
-    cli_password_file_exists: false,
-    cli_remoting_free: false
+    cli_password_file_exists: false
   }.freeze
   CONFIG_CLASS = 'jenkins::cli::config'.freeze
   FACT_PREFIX = 'jenkins_'.freeze

--- a/manifests/cli/config.pp
+++ b/manifests/cli/config.pp
@@ -17,7 +17,6 @@ class jenkins::cli::config(
   Optional[String] $cli_password                  = undef,
   Optional[String] $cli_password_file             = '/tmp/jenkins_credentials_for_puppet',
   Boolean $cli_password_file_exists               = false,
-  Optional[Boolean] $cli_remoting_free            = undef,
   Optional[String] $ssh_private_key_content       = undef,
 ) {
 

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -6,8 +6,7 @@ describe 'jenkins class' do
   context 'default parameters' do
     pp = <<-EOS
     class {'jenkins':
-      cli_remoting_free => true,
-      cli               => true,
+      cli => true,
     }
     EOS
 
@@ -66,8 +65,7 @@ describe 'jenkins class' do
   context 'executors' do
     pp = <<-EOS
     class {'jenkins':
-      executors         => 42,
-      cli_remoting_free => true,
+      executors => 42,
     }
     EOS
 
@@ -92,8 +90,7 @@ describe 'jenkins class' do
   context 'slaveagentport' do
     pp = <<-EOS
       class {'jenkins':
-        slaveagentport    => 7777,
-        cli_remoting_free => true,
+        slaveagentport => 7777,
       }
       EOS
 

--- a/spec/acceptance/job_spec.rb
+++ b/spec/acceptance/job_spec.rb
@@ -32,9 +32,7 @@ EOS
   context 'create' do
     it 'works with no errors' do
       pp = <<-EOS
-      class {'jenkins':
-        cli_remoting_free => true,
-      }
+      include jenkins
 
       # the historical assumption is that this will work without cli => true
       # set on the jenkins class
@@ -63,18 +61,14 @@ EOS
   context 'no replace' do
     it 'does not replace an existing job' do
       pp_create = <<-EOS
-        class {'jenkins':
-          cli_remoting_free => true,
-        }
+        include jenkins
         jenkins::job {'test-noreplace-job':
           config => \'#{test_build_job.gsub('<description>test job</description>', '<description>do not overwrite me</description>')}\',
         }
       EOS
 
       pp_update = <<-EOS
-        class {'jenkins':
-          cli_remoting_free => true,
-        }
+        include jenkins
         jenkins::job {'test-noreplace-job':
           config  => \'#{test_build_job}\',
           replace => false,
@@ -98,9 +92,7 @@ EOS
     pending('Parameter $enabled is now deprecated, no need to test')
     it 'works with no errors' do
       pp = <<-EOS
-      class {'jenkins':
-        cli_remoting_free => true,
-      }
+      include jenkins
 
       jenkins::job { 'test-build-job':
         config  => \'#{test_build_job}\',
@@ -129,10 +121,7 @@ EOS
       # create a test job so it can be deleted; job creation is not what
       # we're intending to be testing here
       pp = <<-EOS
-      class {'jenkins':
-        cli_remoting_free => true,
-      }
-
+      include jenkins
       jenkins::job { 'test-build-job':
         config => \'#{test_build_job}\',
       }
@@ -142,10 +131,7 @@ EOS
 
       # test job deletion
       pp = <<-EOS
-      class {'jenkins':
-        cli_remoting_free => true,
-      }
-
+      include jenkins
       jenkins::job { 'test-build-job':
         ensure => 'absent',
         config => \'#{test_build_job}\',

--- a/spec/acceptance/plugin_spec.rb
+++ b/spec/acceptance/plugin_spec.rb
@@ -39,10 +39,7 @@ describe 'jenkins class', order: :defined do
 
   context 'default parameters' do
     pp = <<-EOS
-    class {'jenkins':
-      cli_remoting_free => true,
-    }
-
+    include jenkins
     jenkins::plugin {'git-plugin':
       name    => 'git',
       version => '2.3.4',
@@ -59,8 +56,7 @@ describe 'jenkins class', order: :defined do
       describe 'installs version 3.5.1-1' do
         pp = <<-EOS
         class {'jenkins':
-          cli_remoting_free => true,
-          purge_plugins     => true,
+          purge_plugins => true,
         }
 
         # dependencies to prevent them from being purged
@@ -88,8 +84,7 @@ describe 'jenkins class', order: :defined do
           ensure => present
         }
         class {'jenkins':
-          cli_remoting_free => true,
-          purge_plugins     => true,
+          purge_plugins => true,
         }
 
         # dependencies to prevent them from being purged
@@ -126,8 +121,7 @@ describe 'jenkins class', order: :defined do
       it 'works with no errors' do
         pp = <<-EOS
         class {'jenkins':
-          cli_remoting_free => true,
-          purge_plugins     => true,
+          purge_plugins => true,
         }
 
         # dependencies to prevent them from being purged
@@ -160,8 +154,7 @@ describe 'jenkins class', order: :defined do
       it 'works with no errors' do
         pp = <<-EOS
         class {'jenkins':
-          cli_remoting_free => true,
-          purge_plugins     => false,
+          purge_plugins => false,
         }
 
         # dependencies to prevent them from being purged

--- a/spec/classes/jenkins_cli_spec.rb
+++ b/spec/classes/jenkins_cli_spec.rb
@@ -16,6 +16,7 @@ describe 'jenkins' do
           let(:params) do
             { cli: true,
               cli_ssh_keyfile: '/path/to/key',
+              cli_username: 'myuser',
               libdir: '/path/to/libdir',
               config_hash: { 'HTTP_PORT' => { 'value' => '9000' } } }
           end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -25,14 +25,10 @@ shared_context 'jenkins' do
 
   let(:base_manifest) do
     <<-EOS
-      class { '::jenkins':
-        cli_remoting_free => true,
-      }
-
-      class { '::jenkins::cli::config':
-        cli_jar           => '#{libdir}/jenkins-cli.jar',
-        puppet_helper     => '#{libdir}/puppet_helper.groovy',
-        cli_remoting_free => true,
+      include jenkins
+      class { 'jenkins::cli::config':
+        cli_jar       => '#{libdir}/jenkins-cli.jar',
+        puppet_helper => '#{libdir}/puppet_helper.groovy',
       }
     EOS
   end


### PR DESCRIPTION
Jenkins 2.54 was released in 2017, which is long EOL. Current versions have even dropped support for the old remoting.