### PR TITLE
Remove deprecated enabled parameter on job

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,6 @@ Build jobs can be managed using the `jenkins::job` define
   }
 ```
 
-#### Disabling a build job
-```puppet
-  jenkins::job { 'test-build-job':
-    enabled => 0,
-    config  => template("${templates}/test-build-job.xml.erb"),
-  }
-```
-
 #### Removing an existing build job
 ```puppet
   jenkins::job { 'test-build-job':

--- a/examples/job-configuration/build.pp
+++ b/examples/job-configuration/build.pp
@@ -3,7 +3,6 @@ class jenkins::job::build(
 # lint:endignore
   $config   = undef,
   $jobname  = $title,
-  $enabled  = 1,
   $ensure   = 'present',
 ) {
 
@@ -16,7 +15,6 @@ class jenkins::job::build(
   jenkins::job { 'build':
     ensure  => $ensure,
     jobname => $jobname,
-    enabled => $enabled,
     config  => $real_content,
   }
 }

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -6,7 +6,6 @@
 # @param template Path to a puppet template() resource containing the Jenkins XML job description.
 #     Will override 'config' if set
 # @param jobname the name of the jenkins job
-# @param enabled deprecated parameter (will have no effect if set)
 # @param ensure choose 'absent' to ensure the job is removed
 # @param difftool Provide a command to execute to compare Jenkins job files
 # @param replace
@@ -16,15 +15,10 @@ define jenkins::job (
   Optional[String] $source                  = undef,
   Optional[Stdlib::Absolutepath] $template  = undef,
   String $jobname                           = $title,
-  Any $enabled                              = undef,
   Enum['present', 'absent'] $ensure         = 'present',
   String $difftool                          = '/usr/bin/diff -b -q',
   Boolean $replace                          = true
 ) {
-  if $enabled {
-    warning("You set \$enabled to ${enabled}, this parameter is now deprecated, nothing will change whatever is its value")
-  }
-
   include jenkins::cli
 
   Class['jenkins::cli']
@@ -49,7 +43,6 @@ define jenkins::job (
     jenkins::job::present { $title:
       config   => $realconfig,
       jobname  => $jobname,
-      enabled  => $enabled,
       difftool => $difftool,
       replace  => $replace,
     }

--- a/manifests/job/present.pp
+++ b/manifests/job/present.pp
@@ -4,14 +4,12 @@
 # @param config The content of the jenkins job config file
 # @param config_file Jenkins job config file (file on disk)
 # @param jobname The name of the jenkins job
-# @param enabled Deprecated parameter (will have no effect if set)
 # @param replace Whether or not to replace the job if it already exists.
 #
 define jenkins::job::present (
   Optional[String] $config      = undef,
   Optional[String] $config_file = undef,
   String $jobname               = $title,
-  Any $enabled                  = undef,
   String $difftool              = '/usr/bin/diff -b -q',
   Boolean $replace              = true,
 ) {
@@ -92,10 +90,5 @@ define jenkins::job::present (
       unless  => "${difftool} ${config_path} ${tmp_config_path}",
       notify  => Exec['reload-jenkins'],
     }
-  }
-
-  # Deprecation warning if $enabled is set
-  if $enabled != undef {
-    warning("You set \$enabled to ${enabled}, this parameter is now deprecated, nothing will change whatever is its value")
   }
 }

--- a/spec/acceptance/job_spec.rb
+++ b/spec/acceptance/job_spec.rb
@@ -88,34 +88,6 @@ EOS
     end
   end
 
-  context 'disable' do
-    pending('Parameter $enabled is now deprecated, no need to test')
-    it 'works with no errors' do
-      pp = <<-EOS
-      include jenkins
-
-      jenkins::job { 'test-build-job':
-        config  => \'#{test_build_job}\',
-        enabled => false,
-      }
-      EOS
-
-      # Run it twice and test for idempotency
-      apply(pp, catch_failures: true)
-      # XXX idempotency is broken with at least jenkins 1.613
-      # apply(pp, :catch_changes => true)
-    end
-
-    describe file('/var/lib/jenkins/jobs/test-build-job/config.xml') do
-      it { is_expected.to be_file }
-      it { is_expected.to be_owned_by 'jenkins' }
-      it { is_expected.to be_grouped_into 'jenkins' }
-      it { is_expected.to be_mode 644 }
-      it { is_expected.to contain '<description>test job</description>' }
-      it { is_expected.to contain '<command>/usr/bin/true</command>' }
-    end
-  end # deprecated param enabled
-
   context 'delete' do
     it 'works with no errors' do
       # create a test job so it can be deleted; job creation is not what


### PR DESCRIPTION
9ef227e97806ba387ba2b9ea82e0ac543376415a deprecated this and made it a noop. This removes the support.