### PR TITLE
download jenkins-cli.jar instead of extracting it from jenkins.war

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -23,11 +23,7 @@ class jenkins::cli {
   }
 
   $jar = "${jenkins::libdir}/jenkins-cli.jar"
-  $extract_jar = "jar -xf ${jenkins::libdir}/jenkins.war WEB-INF/lib/"
-  $move_jar = "mv WEB-INF/lib/cli-*.jar ${jar}"
-  $remove_dir = 'rm -rf WEB-INF'
-  $cli_tries = $jenkins::cli_tries
-  $cli_try_sleep = $jenkins::cli_try_sleep
+  $download_jar = "wget -O ${jar} http://localhost:8080/jnlpJars/jenkins-cli.jar"
 
   # make sure we always call Exec[jenlins-cli] in case
   # the binary does not exist
@@ -36,7 +32,7 @@ class jenkins::cli {
     creates => $jar,
   }
   ~> exec { 'jenkins-cli' :
-    command     => "${extract_jar} && ${move_jar} && ${remove_dir}",
+    command     => "sleep 30 && ${download_jar}",
     path        => ['/bin', '/usr/bin'],
     cwd         => '/tmp',
     refreshonly => true,


### PR DESCRIPTION
… the Jenkins-cli.

https://github.com/voxpupuli/puppet-jenkins/issues/998

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Jenkins CLI is no longer available in the above path, so we need to download it directly from  jnlpJars/jenkins-cli.jar
 WEB-INF/jenkins-cli

-->

#### This Pull Request (PR) fixes the following issues
<!--
directly download jenkins-cli from jnlpJars/jenkins-cli.jar
-->
