### PR TITLE
Fix slave run with additional swarm arguments provided

### DIFF
--- a/templates/jenkins-slave-run.erb
+++ b/templates/jenkins-slave-run.erb
@@ -67,6 +67,6 @@ if [ -n "$TOOL_LOCATIONS" ]; then
 fi
 
 [[ -n "$OTHER_ARGS" ]] &&
-  SLAVE_ARGS+=("$OTHER_ARGS")
+  SLAVE_ARGS+=($OTHER_ARGS)
 
 $JAVA "${SLAVE_ARGS[@]}"


### PR DESCRIPTION
#### Pull Request (PR) description
Quoting OTHER_ARGS breaks usage of the `jenkins::slave::swarm_client_args` parameter when more than 1 argument is needed.

It's very similar to #940.
