### PR TITLE
Don't put unparseable JSON in output

### DIFF
--- a/lib/puppet/provider/jenkins_credentials/cli.rb
+++ b/lib/puppet/provider/jenkins_credentials/cli.rb
@@ -108,7 +108,7 @@ Puppet::Type.type(:jenkins_credentials).provide(:cli, parent: Puppet::X::Jenkins
     begin
       JSON.parse(raw)
     rescue JSON::ParserError
-      raise Puppet::Error, "unable to parse as JSON: {REDACTED}"
+      raise Puppet::Error, 'Unable to parse Jenkins credentials list as JSON'
     end
   end
   private_class_method :credentials_list_json

--- a/lib/puppet/provider/jenkins_credentials/cli.rb
+++ b/lib/puppet/provider/jenkins_credentials/cli.rb
@@ -108,7 +108,7 @@ Puppet::Type.type(:jenkins_credentials).provide(:cli, parent: Puppet::X::Jenkins
     begin
       JSON.parse(raw)
     rescue JSON::ParserError
-      raise Puppet::Error, "unable to parse as JSON: #{raw}"
+      raise Puppet::Error, "unable to parse as JSON: {REDACTED}"
     end
   end
   private_class_method :credentials_list_json


### PR DESCRIPTION
Unparseable JSON may still contain valid credentials or other sensitive data that should not be added to logs in plaintext.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Remove the variable that possibly contains sensitive data from the error message when parsing fails.

#### This Pull Request (PR) fixes the following issues
n/a
