### PR TITLE
support multiple arguments in JENKINS_ARGS separated by spaces

### DIFF
--- a/templates/jenkins-run.erb
+++ b/templates/jenkins-run.erb
@@ -69,7 +69,13 @@ PARAMS+=("--daemon")
 [ -n "$JENKINS_HANDLER_STARTUP" ] && PARAMS+=("--handlerCountStartup=$JENKINS_HANDLER_STARTUP")
 [ -n "$JENKINS_HANDLER_MAX" ] && PARAMS+=("--handlerCountMax=$JENKINS_HANDLER_MAX")
 [ -n "$JENKINS_HANDLER_IDLE" ] && PARAMS+=("--handlerCountMaxIdle=$JENKINS_HANDLER_IDLE")
-[ -n "$JENKINS_ARGS" ] && PARAMS+=("$JENKINS_ARGS")
+if [ -n "$JENKINS_ARGS" ]
+then
+  for separate_arg in $JENKINS_ARGS
+  do
+    PARAMS+=("$separate_arg")
+  done
+fi
 
 if [ "$JENKINS_ENABLE_ACCESS_LOG" = "yes" ]; then
   PARAMS+=("--accessLoggerClassName=winstone.accesslog.SimpleAccessLogger")


### PR DESCRIPTION

#### Pull Request (PR) description
before this change setting mutiple arguments like --sessionTimeout=480 --sessionEviction=28800
would fail when starting jenkins with errors similar to `java.lang.NumberFormatException: For input string: "480 --sessionEviction=28800"`
this means we need to separate each arg and load them separately in the PARAMS bash array

#### This Pull Request (PR) fixes the following issues
N/A
