### PR TITLE
Drop Ubuntu 16.04 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -45,7 +45,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04",
         "18.04"
       ]
     }


### PR DESCRIPTION
puppetlabs-java latest has dropped this and it's EOL anyway.