### PR TITLE
Expand systemd drop-in file to more than just env variables

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,6 +12,6 @@ class jenkins::config {
 
   systemd::dropin_file { 'puppet-overrides.conf':
     unit    => 'jenkins.service',
-    content => epp("${module_name}/jenkins-override.epp", { 'environment' => $config_hash }),
+    content => epp("${module_name}/jenkins-override.epp", { 'dropin_config' => $config_hash }),
   }
 }

--- a/templates/jenkins-override.epp
+++ b/templates/jenkins-override.epp
@@ -1,5 +1,9 @@
-<%| Hash[String, Struct[{value => Any}]] $environment |-%>
+<%| Hash[String, Struct[{value => Any}]] $dropin_config |-%>
 [Service]
-<% $environment.each |$key, $entry| { -%>
+<% $dropin_config.each |$key, $entry| { -%>
+<% if $key =~ '^JENKINS' or $key =~ '^JAVA' { -%>
 Environment="<%= $key %>=<%= $entry['value'] %>"
+<% } else { -%>
+<%= $key %>=<%= $entry['value'] %>
+<% } -%>
 <% } -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Currently the systemd drop-in file can only override environment variables.
I would like to expand this functionality to make it possible to override every configuration in the "[Service]" section of the dropin file.

#### This Pull Request (PR) fixes the following issues

Fixes #1009

