### PR TITLE
Remove PIDFile workaround and deprecated code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,3 @@ jobs:
   puppet:
     name: Puppet
     uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v1
-    with:
-      pidfile_workaround: 'CentOS'

--- a/.sync.yml
+++ b/.sync.yml
@@ -6,7 +6,5 @@ Gemfile:
       - gem: 'retries'
 spec/spec_helper.rb:
   spec_overrides: "require 'rspec/its'"
-.github/workflows/ci.yml:
-  pidfile_workaround: CentOS
 .rubocop.yml:
   unmanaged: true

--- a/.sync.yml
+++ b/.sync.yml
@@ -2,9 +2,6 @@
 Gemfile:
   optional:
     ':test':
-      - gem: 'rspec-its'
       - gem: 'retries'
-spec/spec_helper.rb:
-  spec_overrides: "require 'rspec/its'"
 .rubocop.yml:
   unmanaged: true

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ group :test do
   gem 'coveralls',                  :require => false
   gem 'simplecov-console',          :require => false
   gem 'puppet_metadata', '~> 1.0',  :require => false
-  gem 'rspec-its',                  :require => false
   gem 'retries',                    :require => false
 end
 

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -4,3 +4,10 @@ if versioncmp($facts['facterversion'], '4.0.0') < 0 and $facts['os']['family'] =
     ensure => 'installed',
   }
 }
+
+# jenkins::job::present needs diff
+if $facts['os']['family'] == 'RedHat' {
+  package { 'diffutils':
+    ensure => present,
+  }
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,5 +15,3 @@ if File.exist?(File.join(__dir__, 'default_module_facts.yml'))
     add_custom_fact name.to_sym, value
   end
 end
-
-require 'rspec/its'

--- a/spec/unit/facter/plugins_spec.rb
+++ b/spec/unit/facter/plugins_spec.rb
@@ -11,7 +11,11 @@ describe 'jenkins_plugins', type: :fact do
     Facter.clear
     Facter.loadfacts
     allow(Puppet::Jenkins::Plugins).to receive(:available).and_return(plugins)
-    Facter.fact(:kernel).stub(:value).and_return(kernel)
+
+    overridden_kernel = kernel
+    Facter.add(:kernel, weight: 9999) do
+      setcode { overridden_kernel }
+    end
   end
 
   after { Facter.clear }

--- a/spec/unit/jenkins_plugins_spec.rb
+++ b/spec/unit/jenkins_plugins_spec.rb
@@ -179,6 +179,6 @@ Plugin-Developers: Kohsuke Kawaguchi:kohsuke:,Nicolas De Loof:ndeloof:
 
     it { is_expected.to be_instance_of Hash }
     it { is_expected.to have_key('AdaptivePlugin') }
-    its(:size) { is_expected.to be 1 }
+    it { is_expected.to have_attributes(size: 1) }
   end
 end

--- a/spec/unit/jenkins_plugins_spec.rb
+++ b/spec/unit/jenkins_plugins_spec.rb
@@ -42,7 +42,7 @@ describe Puppet::Jenkins::Plugins do
 
     context 'if jenkins does not exist' do
       before do
-        Puppet::Jenkins.stub(:home_dir).and_return(nil)
+        allow(Puppet::Jenkins).to receive(:home_dir).and_return(nil)
       end
 
       it { is_expected.to be false }
@@ -53,8 +53,8 @@ describe Puppet::Jenkins::Plugins do
       let(:dir_exists) { false }
 
       before do
-        Puppet::Jenkins.stub(:home_dir).and_return(home)
-        File.should_receive(:directory?).with(File.join(home, 'plugins')).and_return(dir_exists)
+        allow(Puppet::Jenkins).to receive(:home_dir).and_return(home)
+        expect(File).to receive(:directory?).with(File.join(home, 'plugins')).and_return(dir_exists)
       end
 
       context 'and the directory exists' do
@@ -74,7 +74,7 @@ describe Puppet::Jenkins::Plugins do
 
     context 'when plugins do not exist' do
       before do
-        described_class.should_receive(:exists?).and_return(false)
+        expect(described_class).to receive(:exists?).and_return(false)
       end
 
       it { is_expected.to be_empty }

--- a/spec/unit/jenkins_spec.rb
+++ b/spec/unit/jenkins_spec.rb
@@ -9,7 +9,7 @@ describe Puppet::Jenkins do
 
     context "when a jenkins user doesn't exist" do
       before do
-        File.should_receive(:expand_path).and_raise(ArgumentError)
+        expect(File).to receive(:expand_path).and_raise(ArgumentError)
       end
 
       it { is_expected.to be_nil }
@@ -19,7 +19,7 @@ describe Puppet::Jenkins do
       let(:home) { '/rspec/jenkins' }
 
       before do
-        File.should_receive(:expand_path).and_return(home)
+        expect(File).to receive(:expand_path).and_return(home)
       end
 
       it { is_expected.to eql home }

--- a/spec/unit/puppet/type/jenkins_job_spec.rb
+++ b/spec/unit/puppet/type/jenkins_job_spec.rb
@@ -45,13 +45,11 @@ describe Puppet::Type.type(:jenkins_job) do
 
           if cfg && param
             it 'displays a diff' do
-              property.stub(:diff).and_return('foo')
-              expect(property).to receive(:diff).once
+              expect(property).to receive(:diff).once.and_return('foo')
               property.change_to_s('foo', 'bar')
             end
           else
             it 'does not display a diff' do
-              property.stub(:diff)
               expect(property).not_to receive :diff
               property.change_to_s('foo', 'bar')
             end


### PR DESCRIPTION
The service is now a native systemd service so there is no pidfile to be tracked. This means we can test on EL8 again.