### PR TITLE
Use structured fact for Jenkins plugin list

### DIFF
--- a/lib/facter/jenkins.rb
+++ b/lib/facter/jenkins.rb
@@ -10,7 +10,6 @@ require_relative '../puppet/jenkins/plugins'
 Facter.add(:jenkins_plugins) do
   confine kernel: 'Linux'
   setcode do
-    plugins = Puppet::Jenkins::Plugins.available
-    plugins.keys.sort.map { |plugin| "#{plugin} #{plugins[plugin][:plugin_version]}" }.join(', ')
+    Puppet::Jenkins::Plugins.available
   end
 end


### PR DESCRIPTION
Pull Request (PR) description
This PR changes the jenkins_plugins fact from a simple string value to a structured fact to avoid the error about a fact value being too long.

This Pull Request (PR) fixes the following issues
Fixes https://github.com/voxpupuli/puppet-jenkins/issues/1048

Maybe this gives too much information as the Hash contains much more than the name and version number that was in the 'old' fact.

It could easily be reduced to only some keys.

```
  "jenkins_plugins": {
    "blueocean-dashboard": {
      "manifest_version": "1.0",
      "archiver_version": "Plexus Archiver",
      "created_by": "Apache Maven",
      "built_by": "olamy",
      "build_jdk": "11.0.13",
      "extension_name": "blueocean-dashboard",
      "specification_title": "The Jenkins Plugins Parent POM Project",
      "implementation_title": "blueocean-dashboard",
      "implementation_version": "1.25.2",
      "group_id": "io.jenkins.blueocean",
      "short_name": "blueocean-dashboard",
      "long_name": "Dashboard for Blue Ocean",
      "url": "https://github.com/jenkinsci/blueocean-plugin/blob/master/blueoce",
      "minimum_java_version": "1.8",
      "plugin_version": "1.25.2",
      "hudson_version": "2.277.4",
      "jenkins_version": "2.277.4",
      "plugin_dependencies": "blueocean-web:1.25.2",
      "plugin_developers": "Thorsten Iberian Sumurai:scherler:,Cliff Meyers:cli",
      "support_dynamic_loading": "true",
      "plugin_license_name": "MIT License",
      "plugin_license_url": "https://opensource.org/licenses/MIT",
      "plugin_scmurl": "https://github.com/jenkinsci/blueocean-plugin/blueocean"
    },
    "blueocean-autofavorite": {
      "manifest_version": "1.0",
      "archiver_version": "Plexus Archiver",
      "created_by": "Apache Maven",
      "built_by": "gmogan",
      "build_jdk": "1.8.0_192",
      "extension_name": "blueocean-autofavorite",
      "specification_title": "Automatically favorites multibranch pipeline jobs",
      "implementation_title": "blueocean-autofavorite",
      "implementation_version": "1.2.4",
      "group_id": "org.jenkins-ci.plugins",
      "short_name": "blueocean-autofavorite",
      "long_name": "Autofavorite for Blue Ocean",
      "url": "https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Autofavori",
      "minimum_java_version": "1.8",
      "plugin_version": "1.2.4",
      "hudson_version": "2.121.1",
      "jenkins_version": "2.121.1",
      "plugin_dependencies": "workflow-job:2.32,branch-api:2.0.11,git-client:2.",
      "plugin_developers": "James Dumay:jdumay:jdumay@cloudbees.com"
    },
    "blueocean": {
      "manifest_version": "1.0",
      "archiver_version": "Plexus Archiver",
      "created_by": "Apache Maven",
...
...
```