### PR TITLE
Install Java 11 on Red Hat OSes

### DIFF
--- a/spec/acceptance/hieradata/common.yaml
+++ b/spec/acceptance/hieradata/common.yaml
@@ -1,3 +1,0 @@
----
-# Latest credentials plugin (1126) requires Jenkins 2.340 while LTS is 2.332
-jenkins::lts: false

--- a/spec/acceptance/hieradata/os/RedHat.yaml
+++ b/spec/acceptance/hieradata/os/RedHat.yaml
@@ -1,0 +1,3 @@
+---
+# Jenkins 2.361.1 requires Java 11 or newer
+java::package: java-11-openjdk-headless


### PR DESCRIPTION
Jenkins 2.361.1 requires Java 11 or newer and breaks with Java 1.8.