### PR TITLE
Add Archlinux support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,6 +14,9 @@
   ],
   "operatingsystem_support": [
     {
+      "operatingsystem": "Archlinux"
+    },
+    {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7",


### PR DESCRIPTION
In e8b57bfa1597acb069f190bd8af8e932089018d3 code was added, but formal support was never declared. This means CI didn't run on it either.

I have no idea if this passes or not. I do not plan to invest too much time into it, but there are conditionals for it so it'd good to actually test that. If they're wrong, we can consider dropping it too.