### PR TITLE
Allow template to be a string

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -13,7 +13,7 @@
 define jenkins::job (
   String $config,
   Optional[String] $source                  = undef,
-  Optional[Stdlib::Absolutepath] $template  = undef,
+  Optional[String[1]] $template             = undef,
   String $jobname                           = $title,
   Enum['present', 'absent'] $ensure         = 'present',
   String $difftool                          = '/usr/bin/diff -b -q',


### PR DESCRIPTION
This is passed to `template()` which accepts relative paths.

Fixes #768