### PR TITLE
Allow puppetlabs/java 9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -60,7 +60,7 @@
     },
     {
       "name": "puppetlabs/java",
-      "version_requirement": ">= 1.0.1 < 9.0.0"
+      "version_requirement": ">= 1.0.1 < 10.0.0"
     },
     {
       "name": "puppet/zypprepo",


### PR DESCRIPTION
I messed up 0032408fab9ea8d3d018f8d8d914bcd208da98fa: there was already a newer release. Marking as a bugfix.