### PR TITLE
Add xml header to the proxy template

### DIFF
--- a/templates/proxy.xml.erb
+++ b/templates/proxy.xml.erb
@@ -1,3 +1,4 @@
+<?xml version='1.1' encoding='UTF-8'?>
 <proxy>
   <name><%= @proxy_host %></name>
   <port><%= @proxy_port %></port>


### PR DESCRIPTION
Fixing problem of xml header. Restarting Jenkins service is adding this header.

#### Pull Request (PR) description
There is no possible to achieve the desired state by Puppet because  the content of proxy.xml file is missing the XML header. 
After restarting the Jenkins service the header is added automatically. So, there is a fight between the proxy template and Jenkins service.

```diff
Notice: /Stage[main]/Jenkins::Proxy/File[/var/lib/jenkins/proxy.xml]/content:
--- /var/lib/jenkins/proxy.xml  2023-10-10 09:34:29.396190879 +0200
+++ /tmp/puppet-file20231010-27492-128ipzr      2023-10-10 09:36:37.746168509 +0200
@@ -1,5 +1,4 @@
-<?xml version='1.1' encoding='UTF-8'?>
 <proxy>
   <name>gate-zrh-os.swissre.com</name>
   <port>9443</port>
-</proxy>
\ No newline at end of file
+</proxy>
```
