### PR TITLE
Cloudbees folder patch 1

### DIFF
--- a/manifests/job/absent.pp
+++ b/manifests/job/absent.pp
@@ -13,8 +13,12 @@ define jenkins::job::absent (
     fail('Management of Jenkins jobs requires \$jenkins::service_ensure to be set to \'running\'')
   }
 
-  $tmp_config_path  = "/tmp/${jobname}-config.xml"
-  $job_dir          = "${jenkins::job_dir}/${jobname}"
+  # in case of a cloudbees-folder element replace all '/' with underscore so only a file without subdirectory is deleted
+  $replaced_jobname = regsubst($jobname, /\//, '_', 'G')
+  $tmp_config_path  = "/tmp/${replaced_jobname}-config.xml"
+  # in case of a cloudbees-folder element inserting sub-directory '/jobs' for every folder level so the existing config file is deleted
+  $job_subdir_name  = regsubst($jobname, /\//, '/jobs/', 'G')
+  $job_dir          = "${jenkins::job_dir}/${job_subdir_name}"
   $config_path      = "${job_dir}/config.xml"
 
   # Temp file to use as stdin for Jenkins CLI executable

--- a/manifests/job/present.pp
+++ b/manifests/job/present.pp
@@ -33,7 +33,9 @@ define jenkins::job::present (
     $tmp_config_path = $config_file
   }
   else {
-    $tmp_config_path    = "/tmp/${jobname}-config.xml"
+    # in case of a cloudbees-folder element replace all '/' with underscore so only a file without subdirectory is created
+    $replaced_jobname      = regsubst($jobname, /\//, '_', 'G')
+    $tmp_config_path    = "/tmp/${replaced_jobname}-config.xml"
     #
     # When a Jenkins job is imported via the cli, Jenkins will
     # re-format the xml file based on its own internal rules.


### PR DESCRIPTION
Compatibility with plugin cloudbees-folder'

#### Pull Request (PR) description
This PR provides the ability to manage elements of type/plugin 'cloudbees-folder'. In this case the name of the job could include slashes for subfolders. So the slashes in the job name have to be replaced by underscore for the temporary created file used for the jenkins api. Also the slashes have to replaced by '/jobs/' for the config.xml of a job while deleting the job via the jenkins api.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
