### PR TITLE
fix cloudbees-folder CI

### DIFF
--- a/spec/acceptance/xtypes/jenkins_job_spec.rb
+++ b/spec/acceptance/xtypes/jenkins_job_spec.rb
@@ -107,7 +107,10 @@ describe 'jenkins_job', order: :defined do
       <<-EOS
         include jenkins
         include jenkins::cli::config
-        jenkins::plugin { 'cloudbees-folder': }
+        jenkins::plugin { 'ionicons-api': }
+        jenkins::plugin { 'cloudbees-folder':
+          version => '6.897.vb_943ea_6b_a_08b_'
+        }
       EOS
     end
 


### PR DESCRIPTION
- the plugin now requires `ionicons-api`, so install it
- pin to 6.897.vb_943ea_6b_a_08b_ as newer versions are not compatible with Jenkins LTS releases

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
