### PR TITLE
Don't notify service when not managing it

### DIFF
--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -20,9 +20,14 @@ class jenkins::proxy {
       mode    => '0644',
     }
 
-    Package['jenkins']
-    -> File[$proxy_xml]
-    ~> Class['jenkins::service']
+    if $jenkins::manage_service {
+      Package['jenkins']
+      -> File[$proxy_xml]
+      ~> Class['jenkins::service']
+    } else {
+      Package['jenkins']
+      -> File[$proxy_xml]
+    }
   } else {
     $url = undef
   }


### PR DESCRIPTION
#### Pull Request (PR) description
The `jenkins::service` class is not included when `$jenkins::manage_service` is false. We should not try to restart it in the `proxy` class if we're not managing it.