### PR TITLE
CentOS: Drop EoL 7/8 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -24,8 +24,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
-        "8",
         "9"
       ]
     },

--- a/spec/acceptance/xtypes/jenkins_credentials_spec.rb
+++ b/spec/acceptance/xtypes/jenkins_credentials_spec.rb
@@ -295,11 +295,13 @@ describe 'jenkins_credentials' do
               'trilead-api',
               'variant',
               'workflow-api',
-              'workflow-job',
               'workflow-scm-step',
               'workflow-step-api',
               'workflow-support',
             ]: }
+            jenkins::plugin { 'workflow-job':
+              version => '1400.v7fd111b_ec82f'
+            }
 
             jenkins_credentials { '7e86e9fb-a8af-480f-b596-7191dc02bf38':
               ensure      => 'present',
@@ -366,11 +368,13 @@ describe 'jenkins_credentials' do
             'workflow-basic-steps',
             'workflow-cps',
             'workflow-durable-task-step',
-            'workflow-job',
             'workflow-scm-step',
             'workflow-step-api',
             'workflow-support',
           ]: }
+          jenkins::plugin { 'workflow-job':
+            version => '1400.v7fd111b_ec82f'
+          }
 
           jenkins_credentials { '562fa23d-a441-4cab-997f-58df6e245813':
             ensure      => 'present',


### PR DESCRIPTION
Both are soonish EoL so we should drop them.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
