### PR TITLE
Update firewall.pp to replace action with jump

### DIFF
--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -5,7 +5,7 @@ class jenkins::firewall {
   assert_private()
 
   firewall { '500 allow Jenkins inbound traffic':
-    action => 'accept',
+    jump   => 'accept',
     state  => 'NEW',
     dport  => [jenkins_port()],
     proto  => 'tcp',


### PR DESCRIPTION
https://forge.puppet.com/modules/puppetlabs/firewall/readme#migration-path-to-v700

The action attribute within the firewall type has been removed as it was merely a restricted version of the jump attribute, both of them managing the same function, this being reasoned as a way to enforce the use of generic parameters. From this point the parameters formerly unique to action should now be passed to jump.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
