### PR TITLE
use apt::keyring to install the Jenkins APT repo key in Debian

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -1,8 +1,6 @@
 # @summary Set up the apt repo on Debian-based distros
 # @api private
-class jenkins::repo::debian (
-  String $gpg_key_id = '63667EE74BBA1F0A08A698725BA31D57EF5975CA',
-) {
+class jenkins::repo::debian {
   assert_private()
 
   include apt
@@ -23,12 +21,5 @@ class jenkins::repo::debian (
       'name'   => 'jenkins.asc',
       'source' => "${location}/${jenkins::repo::gpg_key_filename}",
     },
-    notify   => Exec['check Jenkins OpenPGP key fingerprint'],
-  }
-
-  exec { 'check Jenkins OpenPGP key fingerprint':
-    command     => "/usr/bin/test \"$(/usr/bin/gpg --show-keys --with-colons /etc/apt/keyrings/jenkins.asc | /usr/bin/awk -F: '/^fpr/ {print \$10}' | head -n 1)\" = ${gpg_key_id}",
-    refreshonly => true,
-    require     => Apt::Source['jenkins'],
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

apt-key is not present in Debian Trixie, and because of that the `apt::key` resource doesn't work in that release.  Upstream [puppetlabs-apt](https://github.com/puppetlabs/puppetlabs-apt) advises:

```
Warning apt::key is deprecated in the latest Debian and
Ubuntu releases. Please use apt::keyring instead.
```

We also implement a check for the expected fingerprint, as that's not done by the upstream code (even though it probably should support that?). This way, we will at least get an error in Puppet if the fingerprint doesn't match.

#### This Pull Request (PR) fixes the following issues

Fixes #1129