### PR TITLE
Add new GPG Keys for 2026 Release

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -2,7 +2,7 @@
 # @api private
 class jenkins::repo (
   Stdlib::Httpurl $base_url = 'https://pkg.jenkins.io',
-  String $gpg_key_filename = 'jenkins.io-2023.key',
+  String $gpg_key_filename = 'jenkins.io-2026.key',
   Boolean $enabled = true,
 ) {
   assert_private()

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -1,7 +1,7 @@
 # @summary Set up the apt repo on Debian-based distros
 # @api private
 class jenkins::repo::debian (
-  String $gpg_key_id = '63667EE74BBA1F0A08A698725BA31D57EF5975CA',
+  String $gpg_key_id = '5E386EADB55F01504CAE8BCF7198F4B714ABFC68',
 ) {
   assert_private()
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This Pull Request is adding the new Jenkins Key Ring which is stated here: https://pkg.jenkins.io/debian-stable/
