### PR TITLE
add -http option to jenkins cli on localhost

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -56,7 +56,7 @@ class jenkins::cli {
     delete_undef_values([
       'java',
       "-jar ${jar}",
-      "-http",
+      '-http',
       "-s http://localhost:${port}${prefix}",
       $jenkins::_cli_auth_arg,
     ]),

--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -56,6 +56,7 @@ class jenkins::cli {
     delete_undef_values([
       'java',
       "-jar ${jar}",
+      "-http",
       "-s http://localhost:${port}${prefix}",
       $jenkins::_cli_auth_arg,
     ]),

--- a/manifests/cli_helper.pp
+++ b/manifests/cli_helper.pp
@@ -28,6 +28,7 @@ class jenkins::cli_helper {
       '|',
       '/usr/bin/java',
       "-jar ${cli_jar}",
+      "-http",
       "-s http://127.0.0.1:${port}${prefix}",
       $jenkins::_cli_auth_arg,
       'groovy =',

--- a/manifests/cli_helper.pp
+++ b/manifests/cli_helper.pp
@@ -28,7 +28,7 @@ class jenkins::cli_helper {
       '|',
       '/usr/bin/java',
       "-jar ${cli_jar}",
-      "-http",
+      '-http',
       "-s http://127.0.0.1:${port}${prefix}",
       $jenkins::_cli_auth_arg,
       'groovy =',


### PR DESCRIPTION

#### Pull Request (PR) description

As described in #1144 the localhost/127.0.0.1 connections from jenkins cli (`java -jar jenkins-cli.jar`) fails. By default jenkins-cli.jar use `-websocket`, but connecting to localhost does not work correctly with installation using reverse proxy and report `Unexpected request origin`. Using `-http` for localhost connection works without problem.

#### This Pull Request (PR) fixes the following issues
Should fix #1144 , at least it fixes our error setting executors number (`set_num_executors`).

Before change (it tries to set num executors even though it's currectly set, probably because it cannot read the current value):
```
# /bin/cat /usr/share/java/puppet_helper.groovy | /usr/bin/java -jar /usr/share/java/jenkins-cli.jar -http -s http://localhost:8080 -auth 'jenkins:PASS' groovy = get_num_executors
8

# puppet agent -t
...
...
Notice: /Stage[main]/Jenkins/Jenkins::Cli::Exec[set_num_executors]/Exec[set_num_executors]/returns: CLI handshake failed with status code 403
Notice: /Stage[main]/Jenkins/Jenkins::Cli::Exec[set_num_executors]/Exec[set_num_executors]/returns: Content-Length: 0
Notice: /Stage[main]/Jenkins/Jenkins::Cli::Exec[set_num_executors]/Exec[set_num_executors]/returns: Content-Security-Policy-Report-Only: base-uri 'none'; default-src 'self'; form-action 'self'; frame-ancestors 'self'; img-src 'self' data:; script-src 'report-sample' 'self'; style-src 'report-sample' 'self' 'unsafe-inline'; report-to content-security-policy; report-uri https://SERVER/...
Notice: /Stage[main]/Jenkins/Jenkins::Cli::Exec[set_num_executors]/Exec[set_num_executors]/returns: Date: Wed, 08 Apr 2026 12:05:22 GMT
Notice: /Stage[main]/Jenkins/Jenkins::Cli::Exec[set_num_executors]/Exec[set_num_executors]/returns: Reporting-Endpoints: content-security-policy: https://SERVER/...
Notice: /Stage[main]/Jenkins/Jenkins::Cli::Exec[set_num_executors]/Exec[set_num_executors]/returns: Server: Jetty(12.1.5)
Notice: /Stage[main]/Jenkins/Jenkins::Cli::Exec[set_num_executors]/Exec[set_num_executors]/returns: Vary: Accept-Encoding
Notice: /Stage[main]/Jenkins/Jenkins::Cli::Exec[set_num_executors]/Exec[set_num_executors]/returns: X-CLI-Error: Unexpected request origin (check your reverse proxy settings)
Notice: /Stage[main]/Jenkins/Jenkins::Cli::Exec[set_num_executors]/Exec[set_num_executors]/returns: X-Content-Type-Options: nosniff
Notice: /Stage[main]/Jenkins/Jenkins::Cli::Exec[set_num_executors]/Exec[set_num_executors]/returns: X-Jenkins-Language: en_US
Error: '/bin/cat /usr/share/java/puppet_helper.groovy | /usr/bin/java -jar /usr/share/java/jenkins-cli.jar -s http://127.0.0.1:8080 -auth 'jenkins:PASS' groovy = set_num_executors 8' returned 15 instead of one of [0]
Error: /Stage[main]/Jenkins/Jenkins::Cli::Exec[set_num_executors]/Exec[set_num_executors]/returns: change from 'notrun' to ['0'] failed: '/bin/cat /usr/share/java/puppet_helper.groovy | /usr/bin/java -jar /usr/share/java/jenkins-cli.jar -s http://127.0.0.1:8080 -auth 'jenkins:PASS' groovy = set_num_executors 8' returned 15 instead of one of [0] (corrective)
Notice: /Stage[main]/Jenkins::Cli::Reload/Exec[reload-jenkins]: Dependency Exec[set_num_executors] has failures: true
```

After setting `-http` puppet runs without any error (and if I set other value for num executors, it set back value 8):
```
# /bin/cat /usr/share/java/puppet_helper.groovy | /usr/bin/java -jar /usr/share/java/jenkins-cli.jar -http -s http://localhost:8080 -auth 'jenkins:PASS' groovy = get_num_executors
6

# puppet agent -t
...
...
Notice: /Stage[main]/Jenkins/Jenkins::Cli::Exec[set_num_executors]/Exec[set_num_executors]/returns: executed successfully (corrective)
Info: /Stage[main]/Jenkins/Jenkins::Cli::Exec[set_num_executors]/Exec[set_num_executors]: Scheduling refresh of Class[Jenkins::Cli::Reload]
Info: Class[Jenkins::Cli::Reload]: Scheduling refresh of Exec[reload-jenkins]
Notice: /Stage[main]/Jenkins::Cli::Reload/Exec[reload-jenkins]: Triggered 'refresh' from 1 event
```

Thank you.