### PR TITLE
Allow a custom CLI URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,9 +205,12 @@ interact with the Jenkins API. Users, Credentials, and security model
 configuration are all driven through this script.
 
 When an API-based resource is defined, the Jenkins' CLI is installed and run
-against the local system (127.0.0.1). Jenkins is assumed to be listening on
+against the local system (localhost). Jenkins is assumed to be listening on
 port 8080, but the module is smart enough to notice if you've configured an
-alternate port using jenkins::config_hash['JENKINS_PORT'].
+alternate port using jenkins::config_hash['JENKINS_PORT'].  Unless you are using
+ssh for the cli authentication, the urlbase and port params should be set to
+match up to what you configure in Jenkins Location in your system configuration
+to avoid unexpected origin errors.
 
 Users and credentials are Puppet-managed, meaning that changes made to them
 from outside Puppet will be reset at the next puppet run. In this way, you can

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -56,7 +56,7 @@ have proper permissions setup.
 
 ### Functions
 
-* [`jenkins_port`](#jenkins_port): Return the configurad Jenkins port value (corresponds to /etc/defaults/jenkins -> JENKINS_PORT  Example:      $port = jenkins_port()
+* [`jenkins_port`](#jenkins_port): Return the configured Jenkins port value (corresponds to /etc/defaults/jenkins -> JENKINS_PORT  Example:      $port = jenkins_port()
 * [`jenkins_prefix`](#jenkins_prefix): Return the configured Jenkins prefix value (corresponds to /etc/defaults/jenkins -> PREFIX)  Example:      $prefix = jenkins_prefix()
 
 ### Data types
@@ -198,6 +198,7 @@ The following parameters are available in the `jenkins` class:
 * [`cli_password_file`](#-jenkins--cli_password_file)
 * [`cli_tries`](#-jenkins--cli_tries)
 * [`cli_try_sleep`](#-jenkins--cli_try_sleep)
+* [`urlbase`](#-jenkins--urlbase)
 * [`port`](#-jenkins--port)
 * [`libdir`](#-jenkins--libdir)
 * [`manage_datadirs`](#-jenkins--manage_datadirs)
@@ -503,6 +504,18 @@ Data type: `Integer`
 Seconds between tries to contact jenkins API
 
 Default value: `10`
+
+##### <a name="-jenkins--urlbase"></a>`urlbase`
+
+Data type: `String`
+
+Jenkins base url including protocol (http/https) and hostname
+
+Note that this value is use for CLI communication and does not configure your Jenkins system location
+It should however match the base of your Jenkins Location in system config to prevent CORS
+unexpected Origin errors.
+
+Default value: `'http://localhost'`
 
 ##### <a name="-jenkins--port"></a>`port`
 
@@ -1520,7 +1533,7 @@ Default value: `'present'`
 
 Type: Ruby 3.x API
 
-Return the configurad Jenkins port value
+Return the configured Jenkins port value
 (corresponds to /etc/defaults/jenkins -> JENKINS_PORT
 
 Example:
@@ -1529,7 +1542,7 @@ Example:
 
 #### `jenkins_port()`
 
-Return the configurad Jenkins port value
+Return the configured Jenkins port value
 (corresponds to /etc/defaults/jenkins -> JENKINS_PORT
 
 Example:

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -511,7 +511,7 @@ Data type: `String`
 
 Jenkins base url including protocol (http/https) and hostname
 
-Note that this value is use for CLI communication and does not configure your Jenkins system location
+Note that this value is used for CLI communication and does not configure your Jenkins system location.
 It should however match the base of your Jenkins Location in system config to prevent CORS
 unexpected Origin errors.
 

--- a/lib/puppet/parser/functions/jenkins_port.rb
+++ b/lib/puppet/parser/functions/jenkins_port.rb
@@ -2,7 +2,7 @@
 
 module Puppet::Parser::Functions
   newfunction(:jenkins_port, type: :rvalue, doc: <<-ENDHEREDOC) do |_args|
-    Return the configurad Jenkins port value
+    Return the configured Jenkins port value
     (corresponds to /etc/defaults/jenkins -> JENKINS_PORT
 
     Example:
@@ -11,6 +11,7 @@ module Puppet::Parser::Functions
   ENDHEREDOC
 
     config_hash = lookupvar('jenkins::config_hash')
-    config_hash&.dig('JENKINS_PORT', 'value') || 8080
+    config_port = lookupvar('jenkins::port')
+    config_hash&.dig('JENKINS_PORT', 'value') || config_port
   end
 end

--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -50,13 +50,14 @@ class jenkins::cli {
 
   $port = jenkins_port()
   $prefix = jenkins_prefix()
+  $urlbase = $jenkins::urlbase
 
   # The jenkins cli command with required parameter(s)
   $cmd = join(
     delete_undef_values([
       'java',
       "-jar ${jar}",
-      "-s http://localhost:${port}${prefix}",
+      "-s ${urlbase}:${port}${prefix}",
       $jenkins::_cli_auth_arg,
     ]),
     ' '

--- a/manifests/cli_helper.pp
+++ b/manifests/cli_helper.pp
@@ -11,6 +11,7 @@ class jenkins::cli_helper {
   $cli_jar = $jenkins::cli::jar
   $port = jenkins_port()
   $prefix = jenkins_prefix()
+  $urlbase = $jenkins::urlbase
   $helper_groovy = "${libdir}/puppet_helper.groovy"
 
   file { $helper_groovy:
@@ -28,7 +29,7 @@ class jenkins::cli_helper {
       '|',
       '/usr/bin/java',
       "-jar ${cli_jar}",
-      "-s http://127.0.0.1:${port}${prefix}",
+      "-s ${urlbase}:${port}${prefix}",
       $jenkins::_cli_auth_arg,
       'groovy =',
     ]),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -199,7 +199,7 @@
 # @param urlbase
 #  Jenkins base url including protocol (http/https) and hostname
 #
-#  Note that this value is use for CLI communication and does not configure your Jenkins system location
+#  Note that this value is used for CLI communication and does not configure your Jenkins system location.
 #  It should however match the base of your Jenkins Location in system config to prevent CORS
 #  unexpected Origin errors.
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -196,6 +196,13 @@
 # @param cli_try_sleep
 #   Seconds between tries to contact jenkins API
 #
+# @param urlbase
+#  Jenkins base url including protocol (http/https) and hostname
+#
+#  Note that this value is use for CLI communication and does not configure your Jenkins system location
+#  It should however match the base of your Jenkins Location in system config to prevent CORS
+#  unexpected Origin errors.
+#
 # @param port
 #   Jenkins listening HTTP port
 #
@@ -303,6 +310,7 @@ class jenkins (
   Optional[String] $cli_password_file             = undef,
   Integer $cli_tries                              = 10,
   Integer $cli_try_sleep                          = 10,
+  String $urlbase                                 = 'http://localhost',
   Integer $port                                   = 8080,
   Stdlib::Absolutepath $libdir                    = '/usr/share/java',
   Boolean $manage_datadirs                        = true,

--- a/spec/classes/jenkins_cli_spec.rb
+++ b/spec/classes/jenkins_cli_spec.rb
@@ -45,6 +45,20 @@ describe 'jenkins' do
           end
         end
 
+        context '$cli => true and user/pw and custom url' do
+          let(:params) do
+            { cli: true,
+              cli_username: 'myuser',
+              cli_password: 'mypassword',
+              port: 8443,
+              urlbase: 'https://myjenkins.dom' }
+          end
+
+          it { is_expected.to contain_class('jenkins::cli') }
+          it { is_expected.to contain_exec('jenkins-cli') }
+          it { is_expected.to contain_exec('reload-jenkins').with_command(%r{https://myjenkins.dom:8443}) }
+        end
+
         context '$cli => false' do
           let(:params) { { cli: false } }
 

--- a/spec/defines/jenkins_cli_exec_spec.rb
+++ b/spec/defines/jenkins_cli_exec_spec.rb
@@ -8,7 +8,7 @@ describe 'jenkins::cli::exec' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:helper_cmd) { '/bin/cat /usr/share/java/puppet_helper.groovy | /usr/bin/java -jar /usr/share/java/jenkins-cli.jar -s http://127.0.0.1:8080 groovy =' }
+      let(:helper_cmd) { '/bin/cat /usr/share/java/puppet_helper.groovy | /usr/bin/java -jar /usr/share/java/jenkins-cli.jar -s http://localhost:8080 groovy =' }
 
       describe 'relationships' do
         it do

--- a/spec/defines/jenkins_credentials_spec.rb
+++ b/spec/defines/jenkins_credentials_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'jenkins::credentials' do
   let(:title) { 'foo' }
-  let(:helper_cmd) { '/usr/bin/java -jar cli.jar -s http://127.0.0.1:8080 groovy /var/lib/jenkins/puppet_helper.groovy' }
+  let(:helper_cmd) { '/usr/bin/java -jar cli.jar -s http://localhost:8080 groovy /var/lib/jenkins/puppet_helper.groovy' }
   let(:pre_condition) do
     "class jenkins::cli_helper { $helper_cmd = '#{helper_cmd}' }"
   end

--- a/spec/functions/jenkins_port_spec.rb
+++ b/spec/functions/jenkins_port_spec.rb
@@ -30,6 +30,20 @@ describe 'jenkins_port' do
           is_expected.to run.with_params.and_return('1337')
         end
       end
+
+      context 'with overwritten parameter' do
+        let(:pre_condition) do
+          <<-ENDPUPPET
+          class { 'jenkins':
+            port => 1337,
+          }
+          ENDPUPPET
+        end
+
+        it 'is our port parameter' do
+          is_expected.to run.with_params.and_return(1337)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
Updates the cli and cli_helper command construction to use a new jenkins class parameter for the base url connection rather than being hardcoded to the local loopback interface.  This allows users of the module to customize this to match what they have configured in their system Jenkins Location, which is needed in newer version of Jenkins which check for unexpected request origin.
To support this, also hooked up the existing "port" parameter to be looked at by the jenkins_port function so that can be customized also.

#### This Pull Request (PR) fixes the following issues
Fixes #1150 
Fixes #1144 

